### PR TITLE
feat(features): add Phase 4B regression target construction

### DIFF
--- a/src/app/features/application/targets.py
+++ b/src/app/features/application/targets.py
@@ -1,0 +1,179 @@
+"""Forward-looking regression targets -- training labels for ML models.
+
+All target functions are stateless and produce Polars expressions that
+use **negative shifts** (future data).  These columns must **never**
+appear in live inference -- only during model training.
+
+Column naming convention:
+    ``fwd_logret_{h}`` -- forward log return at horizon *h*.
+    ``fwd_vol_{h}``    -- forward realized volatility at horizon *h*.
+
+The ``fwd_`` prefix distinguishes forward-looking targets from
+backward-looking indicators (``logret_{h}``, ``rv_{w}``).
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+import polars as pl
+
+from src.app.features.domain.value_objects import TargetConfig
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_EPS: Final[float] = 1e-12
+"""Epsilon for division-by-zero protection."""
+
+TARGET_PREFIX: Final[str] = "fwd_"
+"""Public prefix for downstream identification of target columns."""
+
+
+# ===================================================================
+# 1. FORWARD LOG RETURNS
+# ===================================================================
+
+
+def forward_log_return(close: pl.Expr, horizon: int) -> pl.Expr:
+    r"""Compute forward log return at a given horizon.
+
+    .. math::
+
+        r^{\text{fwd}}_t = \ln\!\left(\frac{C_{t+h}}{C_t}\right)
+
+    The last *horizon* rows will be null because no future data is
+    available.
+
+    Note:
+        This is computed directly rather than reusing :func:`log_return`
+        because the shift direction is reversed (negative shift =
+        future data) and reusing would invite sign-confusion bugs.
+
+    Args:
+        close: Close price expression (e.g. ``pl.col("close")``).
+        horizon: Number of bars to look ahead (must be >= 1).
+
+    Returns:
+        Polars expression for the forward log return.
+    """
+    return (close.shift(-horizon) / close).log()
+
+
+# ===================================================================
+# 2. FORWARD REALIZED VOLATILITY
+# ===================================================================
+
+
+def forward_volatility(close: pl.Expr, horizon: int) -> pl.Expr:
+    r"""Compute forward realized volatility at a given horizon.
+
+    Methodology:
+        1. Compute 1-bar log returns: :math:`r_t = \ln(C_t / C_{t-1})`
+        2. Rolling standard deviation over *horizon* bars
+        3. Shift by ``-horizon`` so the value at row *t* reflects the
+           volatility of returns from :math:`[t+1, \ldots, t+h]`
+
+    .. math::
+
+        \sigma^{\text{fwd}}_t = \text{std}(r_{t+1}, \ldots, r_{t+h})
+
+    The last *horizon* rows will be null.
+
+    Args:
+        close: Close price expression (e.g. ``pl.col("close")``).
+        horizon: Number of bars to look ahead (must be >= 2).
+
+    Returns:
+        Polars expression for the forward realized volatility.
+    """
+    logret_1: pl.Expr = (close / close.shift(1)).log()
+    rolling_std: pl.Expr = logret_1.rolling_std(window_size=horizon, min_samples=horizon)
+    return rolling_std.shift(-horizon)
+
+
+# ===================================================================
+# 3. PRIVATE HELPERS
+# ===================================================================
+
+
+def _add_forward_return_targets(config: TargetConfig) -> list[pl.Expr]:
+    """Build forward log-return expressions for all configured horizons.
+
+    Args:
+        config: Target configuration.
+
+    Returns:
+        List of aliased forward log-return expressions.
+    """
+    close: pl.Expr = pl.col(config.close_col)
+    return [forward_log_return(close, h).alias(f"fwd_logret_{h}") for h in config.forward_return_horizons]
+
+
+def _add_forward_vol_targets(config: TargetConfig) -> list[pl.Expr]:
+    """Build forward volatility expressions for all configured horizons.
+
+    Args:
+        config: Target configuration.
+
+    Returns:
+        List of aliased forward volatility expressions.
+    """
+    close: pl.Expr = pl.col(config.close_col)
+    return [forward_volatility(close, h).alias(f"fwd_vol_{h}") for h in config.forward_vol_horizons]
+
+
+# ===================================================================
+# 4. ORCHESTRATOR
+# ===================================================================
+
+
+def compute_all_targets(
+    df: pl.DataFrame,
+    config: TargetConfig,
+) -> pl.DataFrame:
+    """Compute all forward-looking regression targets and append to the DataFrame.
+
+    This is the main entry point for Phase 4B target construction.
+    All targets are native Polars expressions computed in a single
+    ``with_columns`` call.
+
+    **Important:** This function does NOT drop NaN rows -- that is
+    Phase 4C's responsibility (``FeatureMatrixBuilder``).
+
+    Expected input columns:
+        At minimum, the column named by ``config.close_col`` (default
+        ``"close"``).
+
+    Args:
+        df: Polars DataFrame with at least a close price column.
+        config: Target configuration controlling horizons and column names.
+
+    Returns:
+        DataFrame with all target columns appended.  The original
+        columns are preserved.
+    """
+    exprs: list[pl.Expr] = []
+    exprs.extend(_add_forward_return_targets(config))
+    exprs.extend(_add_forward_vol_targets(config))
+    return df.with_columns(exprs)
+
+
+def get_target_column_names(config: TargetConfig) -> list[str]:
+    """Return a sorted list of target column names for the given config.
+
+    Enables downstream code to programmatically identify which columns
+    are forward-looking targets.
+
+    Args:
+        config: Target configuration.
+
+    Returns:
+        Sorted list of target column names
+        (e.g. ``["fwd_logret_1", "fwd_logret_4", ..., "fwd_vol_4", ...]``).
+    """
+    names: list[str] = [f"fwd_logret_{h}" for h in config.forward_return_horizons]
+    names.extend(f"fwd_vol_{h}" for h in config.forward_vol_horizons)
+    return sorted(names)

--- a/src/app/features/domain/value_objects.py
+++ b/src/app/features/domain/value_objects.py
@@ -1,4 +1,4 @@
-"""Feature engineering domain value objects — indicator configuration."""
+"""Feature engineering domain value objects — indicator and target configuration."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ from typing import Annotated, Self
 
 from pydantic import BaseModel
 from pydantic import Field as PydanticField
-from pydantic import model_validator
+from pydantic import field_validator, model_validator
 
 
 class IndicatorConfig(BaseModel, frozen=True):
@@ -142,3 +142,84 @@ class IndicatorConfig(BaseModel, frozen=True):
             msg: str = f"clip_lower ({self.clip_lower}) must be strictly less than clip_upper ({self.clip_upper})"
             raise ValueError(msg)
         return self
+
+
+_MIN_VOL_HORIZON: int = 2
+"""Minimum forward volatility horizon — rolling std needs >= 2 observations."""
+
+
+class TargetConfig(BaseModel, frozen=True):
+    """Configuration for forward-looking regression targets.
+
+    Targets are fundamentally different from indicators: they use future
+    data (negative shifts) and must **never** appear in live inference.
+    A separate config class enforces this semantic boundary.
+
+    Default horizon rationale (for dollar bars producing ~2-3 bars/day):
+        * 1-bar  ≈ 8-12 hours
+        * 4-bar  ≈ 1-2 days
+        * 24-bar ≈ 8-12 days
+
+    Invariants:
+        * ``forward_return_horizons`` must be non-empty with all values >= 1.
+        * ``forward_vol_horizons`` must have all values >= 2
+          (rolling std requires at least 2 observations).
+        * No duplicate values in either horizon tuple.
+    """
+
+    forward_return_horizons: tuple[int, ...] = (1, 4, 24)
+    """Bar-count horizons for forward log returns."""
+
+    forward_vol_horizons: tuple[int, ...] = (4, 24)
+    """Bar-count horizons for forward realized volatility."""
+
+    close_col: str = "close"
+    """Configurable close column name."""
+
+    @field_validator("forward_return_horizons")
+    @classmethod
+    def _validate_return_horizons(cls, v: tuple[int, ...]) -> tuple[int, ...]:
+        """Validate forward return horizons are non-empty, positive, and unique.
+
+        Args:
+            v: Tuple of horizon values.
+
+        Returns:
+            Validated tuple.
+
+        Raises:
+            ValueError: If the tuple is empty, contains values < 1,
+                or has duplicates.
+        """
+        if len(v) == 0:
+            msg: str = "forward_return_horizons must be non-empty"
+            raise ValueError(msg)
+        if any(h < 1 for h in v):
+            msg = f"All forward_return_horizons must be >= 1, got {v}"
+            raise ValueError(msg)
+        if len(v) != len(set(v)):
+            msg = f"forward_return_horizons must not contain duplicates, got {v}"
+            raise ValueError(msg)
+        return v
+
+    @field_validator("forward_vol_horizons")
+    @classmethod
+    def _validate_vol_horizons(cls, v: tuple[int, ...]) -> tuple[int, ...]:
+        """Validate forward volatility horizons have values >= 2 and no duplicates.
+
+        Args:
+            v: Tuple of horizon values.
+
+        Returns:
+            Validated tuple.
+
+        Raises:
+            ValueError: If any value < 2 or there are duplicates.
+        """
+        if any(h < _MIN_VOL_HORIZON for h in v):
+            msg: str = f"All forward_vol_horizons must be >= {_MIN_VOL_HORIZON} (std needs >= 2 observations), got {v}"
+            raise ValueError(msg)
+        if len(v) != len(set(v)):
+            msg = f"forward_vol_horizons must not contain duplicates, got {v}"
+            raise ValueError(msg)
+        return v


### PR DESCRIPTION
## Summary
- Add `TargetConfig` value object to `value_objects.py` with validated forward return horizons (>= 1) and forward volatility horizons (>= 2), no duplicates
- Create `targets.py` with `forward_log_return` and `forward_volatility` pure Polars expression functions using negative shifts (future data)
- Add `compute_all_targets` orchestrator and `get_target_column_names` utility for downstream column identification

## Test plan
- [x] Verify `TargetConfig` defaults construct correctly and validators reject invalid inputs
- [x] Hand-verify `forward_log_return` and `forward_volatility` on a small DataFrame with known prices
- [x] Confirm target columns have `fwd_` prefix and last `h` rows are null
- [x] Run `just lint` — all hooks pass (ruff format, ruff lint, pyright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)