### PR TITLE
feat(features): add Phase 4C feature matrix builder

### DIFF
--- a/src/app/features/application/feature_matrix.py
+++ b/src/app/features/application/feature_matrix.py
@@ -1,0 +1,85 @@
+"""Feature matrix builder — orchestrates indicators + targets into a ready-to-use FeatureSet.
+
+The :class:`FeatureMatrixBuilder` is the single entry point for downstream
+code (profiling, backtest, model training) to obtain a clean feature matrix
+from raw OHLCV data.  It chains indicator computation, optional target
+construction, NaN removal, and metadata assembly.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from src.app.features.application.indicators import compute_all_indicators
+from src.app.features.application.targets import compute_all_targets
+from src.app.features.domain.value_objects import FeatureConfig, FeatureSet
+
+
+class FeatureMatrixBuilder:
+    """Stateless builder that assembles a complete feature matrix.
+
+    No constructor dependencies — pure computation, no I/O.  Call
+    :meth:`build` with an OHLCV DataFrame and a :class:`FeatureConfig`
+    to get a :class:`FeatureSet` back.
+    """
+
+    def build(self, df: pl.DataFrame, config: FeatureConfig) -> FeatureSet:
+        """Build a complete feature matrix from raw OHLCV data.
+
+        Pipeline:
+            1. Compute backward-looking indicators.
+            2. Compute forward-looking targets (if ``config.compute_targets``).
+            3. Identify new feature and target columns by diffing column sets.
+            4. Drop rows with NaN in computed columns (if ``config.drop_na``).
+            5. Return a :class:`FeatureSet` with metadata.
+
+        Args:
+            df: Polars DataFrame with OHLCV columns
+                (``open``, ``high``, ``low``, ``close``, ``volume``).
+            config: Composite configuration controlling the build pipeline.
+
+        Returns:
+            A :class:`FeatureSet` containing the clean DataFrame and metadata.
+        """
+        base_columns: list[str] = df.columns
+
+        # Step 1: backward-looking indicators
+        result: pl.DataFrame = compute_all_indicators(df, config.indicator_config)
+        feature_columns: tuple[str, ...] = self._identify_new_columns(base_columns, result.columns)
+
+        # Step 2: forward-looking targets (optional)
+        target_columns: tuple[str, ...] = ()
+        if config.compute_targets:
+            cols_before_targets: list[str] = result.columns
+            result = compute_all_targets(result, config.target_config)
+            target_columns = self._identify_new_columns(cols_before_targets, result.columns)
+
+        # Step 3: record raw row count, then drop NaNs
+        n_rows_raw: int = len(result)
+        if config.drop_na:
+            subset: list[str] = list(feature_columns) + list(target_columns)
+            result = result.drop_nulls(subset=subset)
+
+        n_rows_clean: int = len(result)
+
+        return FeatureSet(
+            df=result,
+            feature_columns=feature_columns,
+            target_columns=target_columns,
+            n_rows_raw=n_rows_raw,
+            n_rows_clean=n_rows_clean,
+        )
+
+    @staticmethod
+    def _identify_new_columns(before: list[str], after: list[str]) -> tuple[str, ...]:
+        """Return sorted tuple of columns present in *after* but not in *before*.
+
+        Args:
+            before: Column names before computation.
+            after: Column names after computation.
+
+        Returns:
+            Sorted tuple of newly added column names.
+        """
+        before_set: set[str] = set(before)
+        return tuple(sorted(col for col in after if col not in before_set))

--- a/src/app/features/domain/value_objects.py
+++ b/src/app/features/domain/value_objects.py
@@ -1,10 +1,11 @@
-"""Feature engineering domain value objects — indicator and target configuration."""
+"""Feature engineering domain value objects — indicator, target, and matrix configuration."""
 
 from __future__ import annotations
 
 from typing import Annotated, Self
 
-from pydantic import BaseModel
+import polars as pl
+from pydantic import BaseModel, ConfigDict
 from pydantic import Field as PydanticField
 from pydantic import field_validator, model_validator
 
@@ -223,3 +224,101 @@ class TargetConfig(BaseModel, frozen=True):
             msg = f"forward_vol_horizons must not contain duplicates, got {v}"
             raise ValueError(msg)
         return v
+
+
+class FeatureConfig(BaseModel, frozen=True):
+    """Composite configuration for the feature matrix build pipeline.
+
+    Bundles indicator and target settings so that downstream callers
+    (profiling, backtest, model training) pass a single config object.
+
+    Attributes:
+        indicator_config: Controls all backward-looking indicator parameters.
+        target_config: Controls all forward-looking target horizons.
+        drop_na: Whether to drop rows with any NaN in computed columns.
+        compute_targets: Set ``False`` for live inference where future data
+            does not exist.
+    """
+
+    indicator_config: IndicatorConfig = PydanticField(
+        default_factory=IndicatorConfig,  # type: ignore[reportArgumentType]  # pyright vs pydantic Annotated defaults
+    )
+    target_config: TargetConfig = PydanticField(default_factory=TargetConfig)
+    drop_na: bool = True
+    compute_targets: bool = True
+
+
+class FeatureSet(BaseModel, frozen=True):
+    """Structured output from :class:`FeatureMatrixBuilder`.
+
+    Contains the ready-to-use DataFrame together with metadata that
+    downstream consumers need (column partitioning, row-count diagnostics).
+
+    Attributes:
+        df: Full DataFrame with OHLCV + indicators + optional targets.
+        feature_columns: Sorted tuple of backward-looking indicator column names.
+        target_columns: Sorted tuple of forward-looking target column names
+            (empty when ``compute_targets=False``).
+        n_rows_raw: Row count before NaN dropping (for diagnostics).
+        n_rows_clean: Row count after NaN dropping.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    df: pl.DataFrame
+    feature_columns: tuple[str, ...]
+    target_columns: tuple[str, ...]
+    n_rows_raw: int
+    n_rows_clean: int
+
+    @model_validator(mode="after")
+    def _clean_leq_raw(self) -> Self:
+        """Ensure clean row count does not exceed raw row count.
+
+        Returns:
+            Validated instance.
+
+        Raises:
+            ValueError: If ``n_rows_clean`` exceeds ``n_rows_raw``.
+        """
+        if self.n_rows_clean > self.n_rows_raw:
+            msg: str = f"n_rows_clean ({self.n_rows_clean}) must be <= n_rows_raw ({self.n_rows_raw})"
+            raise ValueError(msg)
+        return self
+
+    @model_validator(mode="after")
+    def _clean_matches_df(self) -> Self:
+        """Ensure clean row count matches the DataFrame length.
+
+        Returns:
+            Validated instance.
+
+        Raises:
+            ValueError: If ``n_rows_clean`` does not equal ``len(df)``.
+        """
+        df_len: int = len(self.df)
+        if self.n_rows_clean != df_len:
+            msg: str = f"n_rows_clean ({self.n_rows_clean}) must equal len(df) ({df_len})"
+            raise ValueError(msg)
+        return self
+
+    @model_validator(mode="after")
+    def _columns_exist(self) -> Self:
+        """Ensure all declared feature and target columns exist in the DataFrame.
+
+        Returns:
+            Validated instance.
+
+        Raises:
+            ValueError: If any declared column is missing from the DataFrame.
+        """
+        df_cols: set[str] = set(self.df.columns)
+        missing_features: set[str] = set(self.feature_columns) - df_cols
+        if missing_features:
+            msg: str = f"Feature columns missing from df: {sorted(missing_features)}"
+            raise ValueError(msg)
+        missing_targets: set[str] = set(self.target_columns) - df_cols
+        if missing_targets:
+            msg = f"Target columns missing from df: {sorted(missing_targets)}"
+            raise ValueError(msg)
+        return self


### PR DESCRIPTION
## Summary
- Add `FeatureConfig` (frozen, composite config bundling `IndicatorConfig` + `TargetConfig`) and `FeatureSet` (frozen, structured output with DataFrame + metadata) value objects to `value_objects.py`
- Create `FeatureMatrixBuilder` orchestrator in `feature_matrix.py` — stateless builder that chains `compute_all_indicators` → `compute_all_targets` → column diffing → `drop_nulls` → `FeatureSet`
- Supports `compute_targets=False` for live inference (no forward-looking columns)
- `FeatureSet` includes three model validators ensuring `n_rows_clean <= n_rows_raw`, `n_rows_clean == len(df)`, and all declared columns exist

## Test plan
- [x] `just lint` passes (ruff format + ruff lint + pyright) ✅
- [x] Smoke test: construct small OHLCV DataFrame, build with default config, verify feature/target columns present, no NaNs, warmup rows dropped
- [x] Verify `compute_targets=False` produces empty `target_columns` and no `fwd_*` columns
- [x] Full test coverage in Phase 4E

🤖 Generated with [Claude Code](https://claude.com/claude-code)