### PR TITLE
feat(profiling): Phase 5pre foundation & validation hardening (#56)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
     "alembic>=1.18.4",
+    "arch>=8.0.0",
     "bokeh>=3.9.0",
     "duckdb>=1.4.4",
     "duckdb-engine>=0.17.0",

--- a/src/app/features/application/validation.py
+++ b/src/app/features/application/validation.py
@@ -32,6 +32,50 @@ _EPS: Final[float] = 1e-12
 # ===================================================================
 
 
+def block_permute(
+    target: np.ndarray[tuple[int], np.dtype[np.float64]],
+    block_size: int,
+    rng: np.random.Generator,
+) -> np.ndarray[tuple[int], np.dtype[np.float64]]:
+    """Permute an array by shuffling contiguous blocks.
+
+    Preserves within-block autocorrelation while breaking the
+    feature-target alignment.  This produces a more conservative null
+    distribution than element-wise permutation when the target has
+    serial dependence.
+
+    Args:
+        target: 1-D target array to permute.
+        block_size: Number of consecutive elements per block.
+            The last block may be shorter.
+        rng: NumPy random generator for reproducibility.
+
+    Returns:
+        A new array with blocks shuffled.  The marginal distribution
+        is preserved; only the temporal ordering changes.
+    """
+    n: int = len(target)
+    if block_size >= n:
+        return target.copy()
+
+    n_full_blocks: int = n // block_size
+    remainder: int = n % block_size
+    n_blocks: int = n_full_blocks + (1 if remainder > 0 else 0)
+
+    # Split into blocks
+    blocks: list[np.ndarray[tuple[int], np.dtype[np.float64]]] = []
+    for i in range(n_blocks):
+        start: int = i * block_size
+        end: int = min(start + block_size, n)
+        blocks.append(target[start:end])
+
+    # Shuffle block order
+    permuted_indices: np.ndarray[tuple[int], np.dtype[np.intp]] = rng.permutation(n_blocks)
+    shuffled_blocks: list[np.ndarray[tuple[int], np.dtype[np.float64]]] = [blocks[i] for i in permuted_indices]
+
+    return np.concatenate(shuffled_blocks)
+
+
 def compute_mi_score(
     feature: np.ndarray[tuple[int], np.dtype[np.float64]],
     target: np.ndarray[tuple[int], np.dtype[np.float64]],
@@ -60,14 +104,20 @@ def compute_mi_null_distribution(
     target: np.ndarray[tuple[int], np.dtype[np.float64]],
     n_permutations: int,
     random_seed: int,
+    block_size: int = 1,
 ) -> np.ndarray[tuple[int], np.dtype[np.float64]]:
-    """Build a null distribution for MI by permuting the target.
+    """Build a null distribution for MI by block-permuting the target.
+
+    When ``block_size=1`` this is equivalent to element-wise permutation.
+    Larger block sizes preserve within-block autocorrelation for a more
+    conservative null.
 
     Args:
         feature: 1-D feature array.
         target: 1-D target array.
         n_permutations: Number of shuffles.
         random_seed: Base random seed.
+        block_size: Block size for block permutation.
 
     Returns:
         Array of MI scores under the null hypothesis.
@@ -75,7 +125,7 @@ def compute_mi_null_distribution(
     rng: np.random.Generator = np.random.default_rng(random_seed)
     null_mis: np.ndarray[tuple[int], np.dtype[np.float64]] = np.empty(n_permutations, dtype=np.float64)
     for i in range(n_permutations):
-        shuffled_target: np.ndarray[tuple[int], np.dtype[np.float64]] = rng.permutation(target)
+        shuffled_target: np.ndarray[tuple[int], np.dtype[np.float64]] = block_permute(target, block_size, rng)
         null_mis[i] = compute_mi_score(feature, shuffled_target, random_seed=random_seed + i + 1)
     return null_mis
 
@@ -164,7 +214,7 @@ def evaluate_single_feature_ridge(
     feature: np.ndarray[tuple[int], np.dtype[np.float64]],
     target: np.ndarray[tuple[int], np.dtype[np.float64]],
     ridge_alpha: float,
-    train_fraction: float = 0.7,
+    train_fraction: float,
 ) -> tuple[float, float]:
     """Fit single-feature Ridge on temporal train split, evaluate on test split.
 
@@ -194,12 +244,14 @@ def compute_ridge_null_distribution(  # noqa: PLR0913, PLR0917
     n_permutations: int,
     ridge_alpha: float,
     random_seed: int,
-    train_fraction: float = 0.7,
-) -> tuple[np.ndarray[tuple[int], np.dtype[np.float64]], np.ndarray[tuple[int], np.dtype[np.float64]]]:
-    """Build null distributions for DA and DC-MAE by permuting the target.
+    train_fraction: float,
+    block_size: int = 1,
+) -> np.ndarray[tuple[int], np.dtype[np.float64]]:
+    """Build a null distribution for DA by block-permuting the target.
 
-    Permutation shuffles the full target BEFORE the temporal split,
-    which is correct — both observed and null use the same split boundary.
+    Block permutation preserves within-block autocorrelation while
+    breaking feature-target alignment.  DC-MAE is no longer computed
+    in the null loop (it is a simple observed diagnostic instead).
 
     Args:
         feature: 1-D feature array.
@@ -208,21 +260,19 @@ def compute_ridge_null_distribution(  # noqa: PLR0913, PLR0917
         ridge_alpha: Ridge regularisation parameter.
         random_seed: Base random seed.
         train_fraction: Fraction of data for training (forwarded to Ridge).
+        block_size: Block size for block permutation.
 
     Returns:
-        Tuple of (DA null array, DC-MAE null array).
+        DA null array (1-D, length ``n_permutations``).
     """
     rng: np.random.Generator = np.random.default_rng(random_seed)
     null_da: np.ndarray[tuple[int], np.dtype[np.float64]] = np.empty(n_permutations, dtype=np.float64)
-    null_dc_mae: np.ndarray[tuple[int], np.dtype[np.float64]] = np.empty(n_permutations, dtype=np.float64)
     for i in range(n_permutations):
-        shuffled_target: np.ndarray[tuple[int], np.dtype[np.float64]] = rng.permutation(target)
+        shuffled_target: np.ndarray[tuple[int], np.dtype[np.float64]] = block_permute(target, block_size, rng)
         da_i: float
-        dc_i: float
-        da_i, dc_i = evaluate_single_feature_ridge(feature, shuffled_target, ridge_alpha, train_fraction)
+        da_i, _ = evaluate_single_feature_ridge(feature, shuffled_target, ridge_alpha, train_fraction)
         null_da[i] = da_i
-        null_dc_mae[i] = dc_i
-    return null_da, null_dc_mae
+    return null_da
 
 
 def classify_feature_group(feature_name: str, feature_groups: dict[str, tuple[str, ...]]) -> str:
@@ -545,6 +595,7 @@ class FeatureValidator:
                 target,
                 config.n_permutations_mi,
                 seed_j,
+                block_size=config.permutation_block_size,
             )
             p_val: float = compute_empirical_pvalue(observed_mi, null_dist)
             mi_scores.append(observed_mi)
@@ -590,21 +641,23 @@ class FeatureValidator:
             feat_col: np.ndarray[tuple[int], np.dtype[np.float64]] = feature_matrix[:, j]
             da: float
             dc: float
-            da, dc = evaluate_single_feature_ridge(feat_col, target, config.ridge_alpha)
+            da, dc = evaluate_single_feature_ridge(
+                feat_col,
+                target,
+                config.ridge_alpha,
+                config.ridge_train_ratio,
+            )
 
-            null_da: np.ndarray[tuple[int], np.dtype[np.float64]]
-            null_dc: np.ndarray[tuple[int], np.dtype[np.float64]]
-            null_da, null_dc = compute_ridge_null_distribution(
+            null_da: np.ndarray[tuple[int], np.dtype[np.float64]] = compute_ridge_null_distribution(
                 feat_col,
                 target,
                 config.n_permutations_ridge,
                 config.ridge_alpha,
                 seed_j,
+                train_fraction=config.ridge_train_ratio,
+                block_size=config.permutation_block_size,
             )
             da_null_mean: float = float(np.mean(null_da))
-            dc_mae_null_mean: float = (
-                float(np.mean(null_dc[np.isfinite(null_dc)])) if np.any(np.isfinite(null_dc)) else float("inf")
-            )
             da_pval: float = compute_empirical_pvalue(da, null_da)
 
             da_scores.append(da)
@@ -612,7 +665,8 @@ class FeatureValidator:
             da_pvalues.append(da_pval)
             da_beats.append(da_pval < config.alpha)
             dc_maes.append(dc)
-            dc_mae_null_means.append(dc_mae_null_mean)
+            # DC-MAE is now a simple observed diagnostic — no null distribution
+            dc_mae_null_means.append(float("nan"))
 
         n_beats: int = sum(da_beats)
         logger.info("Ridge test done: {}/{} features beat DA null", n_beats, n_features)
@@ -680,6 +734,7 @@ class FeatureValidator:
                     window_target,
                     config.n_permutations_stability,
                     seed_wf,
+                    block_size=config.permutation_block_size,
                 )
                 p_val: float = compute_empirical_pvalue(observed_mi, null_dist)
                 if p_val < config.alpha:

--- a/src/app/features/domain/entities.py
+++ b/src/app/features/domain/entities.py
@@ -26,7 +26,8 @@ class FeatureValidationResult(BaseModel, frozen=True):
         da_pvalue: Empirical p-value from Ridge DA null distribution.
         da_beats_null: Whether DA empirical p-value < alpha.
         dc_mae: Direction-conditional MAE (only correct-sign predictions).
-        dc_mae_null_mean: Mean DC-MAE from Ridge null distribution.
+        dc_mae_null_mean: Mean DC-MAE from Ridge null distribution, or ``nan``
+            when not computed (DC-MAE is now an observed diagnostic only).
         stability_score: Fraction of temporal windows where MI is significant.
         is_stable: Whether stability_score >= threshold.
         group: Feature group name from prefix mapping.
@@ -46,7 +47,8 @@ class FeatureValidationResult(BaseModel, frozen=True):
     da_beats_null: bool
 
     dc_mae: Annotated[float, PydanticField(ge=0)]
-    dc_mae_null_mean: Annotated[float, PydanticField(ge=0)]
+    dc_mae_null_mean: float
+    """Mean DC-MAE from null distribution, or ``nan`` when not computed."""
 
     stability_score: Annotated[float, PydanticField(ge=0, le=1)]
     is_stable: bool

--- a/src/app/features/domain/value_objects.py
+++ b/src/app/features/domain/value_objects.py
@@ -293,6 +293,16 @@ class ValidationConfig(BaseModel, frozen=True):
         PydanticField(default=1.0, gt=0, description="Ridge regularisation strength"),
     ]
 
+    ridge_train_ratio: Annotated[
+        float,
+        PydanticField(default=0.7, gt=0, lt=1, description="Temporal train fraction for Ridge evaluation"),
+    ]
+
+    permutation_block_size: Annotated[
+        int,
+        PydanticField(default=50, ge=1, description="Block size for block-permutation null distributions"),
+    ]
+
     random_seed: int = 42
     """Seed for reproducibility."""
 

--- a/src/app/profiling/__init__.py
+++ b/src/app/profiling/__init__.py
@@ -1,0 +1,1 @@
+"""Statistical profiling module."""

--- a/src/app/profiling/application/__init__.py
+++ b/src/app/profiling/application/__init__.py
@@ -1,0 +1,1 @@
+"""Profiling application layer."""

--- a/src/app/profiling/application/stationarity.py
+++ b/src/app/profiling/application/stationarity.py
@@ -1,0 +1,210 @@
+"""Stationarity screening via joint ADF + KPSS testing.
+
+Uses the ML-research path (Pandas / NumPy / statsmodels) per CLAUDE.md.
+The conversion boundary is at the ``screen()`` method entry point.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pandas as pd  # type: ignore[import-untyped]
+from loguru import logger
+from statsmodels.tsa.stattools import adfuller, kpss  # type: ignore[import-untyped]
+
+from src.app.profiling.domain.value_objects import (
+    StationarityReport,
+    StationarityTestResult,
+)
+
+
+_KNOWN_TRANSFORMATIONS: dict[str, str] = {
+    "atr_": "pct_atr",
+    "amihud_": "rolling_zscore",
+    "hurst_": "first_difference",
+    "bbwidth_": "first_difference",
+}
+"""Prefix-to-transformation mapping for known non-stationary feature families."""
+
+
+def _suggest_transformation(feature_name: str) -> str | None:
+    """Suggest a transformation for a non-stationary feature based on its prefix.
+
+    Args:
+        feature_name: Column name of the feature.
+
+    Returns:
+        Suggested transformation string, or ``None`` if no known transformation applies.
+    """
+    for prefix, transform in _KNOWN_TRANSFORMATIONS.items():
+        if feature_name.startswith(prefix):
+            return transform
+    return None
+
+
+def _classify_stationarity(
+    adf_rejects: bool,
+    kpss_rejects: bool,
+) -> str:
+    """Classify feature stationarity from joint ADF + KPSS test outcomes.
+
+    Args:
+        adf_rejects: Whether ADF rejects its null (unit root).
+        kpss_rejects: Whether KPSS rejects its null (stationarity).
+
+    Returns:
+        One of "stationary", "trend_stationary", "unit_root", "inconclusive".
+    """
+    if adf_rejects and not kpss_rejects:
+        return "stationary"
+    if adf_rejects and kpss_rejects:
+        return "trend_stationary"
+    if not adf_rejects and kpss_rejects:
+        return "unit_root"
+    return "inconclusive"
+
+
+def _run_adf(series: np.ndarray[tuple[int], np.dtype[np.float64]]) -> tuple[float, float]:
+    """Run the Augmented Dickey-Fuller test.
+
+    Args:
+        series: 1-D array of values (must not contain NaN/inf).
+
+    Returns:
+        Tuple of (test_statistic, p_value).
+    """
+    # adfuller returns a heterogeneous tuple; statsmodels stubs are incomplete
+    result: tuple[object, ...] = adfuller(series, autolag="AIC")  # type: ignore[assignment]
+    statistic: float = float(result[0])  # type: ignore[arg-type]
+    pvalue: float = float(result[1])  # type: ignore[arg-type]
+    return statistic, pvalue
+
+
+def _run_kpss(series: np.ndarray[tuple[int], np.dtype[np.float64]]) -> tuple[float, float]:
+    """Run the KPSS test for level stationarity.
+
+    KPSS issues ``InterpolationWarning`` when the p-value is outside
+    the tabulated range.  We suppress the warning and clamp the p-value
+    to [0, 1].
+
+    Args:
+        series: 1-D array of values (must not contain NaN/inf).
+
+    Returns:
+        Tuple of (test_statistic, p_value).
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        # kpss returns a heterogeneous tuple; statsmodels stubs are incomplete
+        result: tuple[object, ...] = kpss(series, regression="c", nlags="auto")  # type: ignore[assignment]
+    statistic: float = float(result[0])  # type: ignore[arg-type]
+    pvalue: float = float(np.clip(result[1], 0.0, 1.0))  # type: ignore[arg-type]
+    return statistic, pvalue
+
+
+class StationarityScreener:
+    """Screen features for stationarity using joint ADF + KPSS testing.
+
+    This screener uses Pandas DataFrames as input because the underlying
+    ``statsmodels`` functions expect NumPy arrays.  The conversion boundary
+    is at the ``screen()`` method.
+
+    Classification logic (joint hypothesis):
+        - ADF rejects (p < alpha) AND KPSS doesn't reject (p >= alpha) -> "stationary"
+        - ADF rejects AND KPSS rejects -> "trend_stationary"
+        - ADF doesn't reject AND KPSS rejects -> "unit_root"
+        - Neither rejects -> "inconclusive"
+    """
+
+    def screen(  # noqa: PLR6301
+        self,
+        df: pd.DataFrame,
+        feature_names: list[str],
+        asset: str,
+        bar_type: str,
+        alpha: float = 0.05,
+    ) -> StationarityReport:
+        """Screen all features for stationarity.
+
+        Args:
+            df: Pandas DataFrame containing the feature columns.
+            feature_names: List of feature column names to test.
+            asset: Asset symbol for the report metadata.
+            bar_type: Bar type identifier for the report metadata.
+            alpha: Significance level for both ADF and KPSS tests.
+
+        Returns:
+            StationarityReport with per-feature results.
+
+        Raises:
+            ValueError: If any feature column contains NaN or inf values.
+        """
+        logger.info(
+            "Screening {} features for stationarity (asset={}, bar_type={}, alpha={})",
+            len(feature_names),
+            asset,
+            bar_type,
+            alpha,
+        )
+
+        results: list[StationarityTestResult] = []
+        n_stationary: int = 0
+
+        for fname in feature_names:
+            series: np.ndarray[tuple[int], np.dtype[np.float64]] = df[fname].to_numpy(dtype=np.float64)
+
+            if np.any(np.isnan(series)) or np.any(np.isinf(series)):
+                msg: str = f"Feature '{fname}' contains NaN or inf values"
+                raise ValueError(msg)
+
+            adf_stat: float
+            adf_pval: float
+            adf_stat, adf_pval = _run_adf(series)
+
+            kpss_stat: float
+            kpss_pval: float
+            kpss_stat, kpss_pval = _run_kpss(series)
+
+            adf_rejects: bool = adf_pval < alpha
+            kpss_rejects: bool = kpss_pval < alpha
+
+            classification: str = _classify_stationarity(adf_rejects, kpss_rejects)
+            is_stationary: bool = classification == "stationary"
+
+            suggested: str | None = None
+            if not is_stationary:
+                suggested = _suggest_transformation(fname)
+
+            if is_stationary:
+                n_stationary += 1
+
+            results.append(
+                StationarityTestResult(
+                    feature_name=fname,
+                    adf_statistic=adf_stat,
+                    adf_pvalue=adf_pval,
+                    kpss_statistic=kpss_stat,
+                    kpss_pvalue=kpss_pval,
+                    is_stationary=is_stationary,
+                    classification=classification,
+                    suggested_transformation=suggested,
+                ),
+            )
+
+        n_non_stationary: int = len(results) - n_stationary
+        logger.info(
+            "Stationarity screening done: {}/{} stationary, {}/{} non-stationary",
+            n_stationary,
+            len(feature_names),
+            n_non_stationary,
+            len(feature_names),
+        )
+
+        return StationarityReport(
+            results=tuple(results),
+            n_stationary=n_stationary,
+            n_non_stationary=n_non_stationary,
+            asset=asset,
+            bar_type=bar_type,
+        )

--- a/src/app/profiling/domain/__init__.py
+++ b/src/app/profiling/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Profiling domain layer."""

--- a/src/app/profiling/domain/value_objects.py
+++ b/src/app/profiling/domain/value_objects.py
@@ -1,0 +1,269 @@
+"""Profiling domain value objects -- data partitions, sample tiers, and stationarity results."""
+
+from __future__ import annotations
+
+from datetime import datetime, UTC
+from enum import Enum
+from typing import Annotated, Self
+
+import polars as pl
+from pydantic import BaseModel
+from pydantic import Field as PydanticField
+from pydantic import model_validator
+
+
+class DataPartition(BaseModel, frozen=True):
+    """Project-level authoritative temporal partition for data usage.
+
+    Defines non-overlapping time boundaries that control which data
+    is used for feature selection, model development, and final holdout
+    evaluation.  This prevents information leakage across research phases.
+
+    Invariants:
+        * ``feature_selection_start < feature_selection_end``
+        * ``model_dev_start < model_dev_end``
+        * ``holdout_start >= model_dev_end`` (no overlap between dev and holdout)
+        * Feature selection period must be contained within model development period
+    """
+
+    feature_selection_start: datetime
+    """Start of the feature selection period (inclusive)."""
+
+    feature_selection_end: datetime
+    """End of the feature selection period (exclusive)."""
+
+    model_dev_start: datetime
+    """Start of the model development period (inclusive)."""
+
+    model_dev_end: datetime
+    """End of the model development period (exclusive)."""
+
+    holdout_start: datetime
+    """Start of the final holdout period (inclusive). Extends to end of data."""
+
+    @model_validator(mode="after")
+    def _validate_partition_order(self) -> Self:
+        """Ensure partitions are properly ordered and non-overlapping.
+
+        Returns:
+            Validated instance.
+
+        Raises:
+            ValueError: If partition boundaries violate ordering constraints.
+        """
+        if self.feature_selection_start >= self.feature_selection_end:
+            msg: str = (
+                f"feature_selection_start ({self.feature_selection_start}) "
+                f"must be < feature_selection_end ({self.feature_selection_end})"
+            )
+            raise ValueError(msg)
+        if self.model_dev_start >= self.model_dev_end:
+            msg = f"model_dev_start ({self.model_dev_start}) must be < model_dev_end ({self.model_dev_end})"
+            raise ValueError(msg)
+        if self.holdout_start < self.model_dev_end:
+            msg = f"holdout_start ({self.holdout_start}) must be >= model_dev_end ({self.model_dev_end})"
+            raise ValueError(msg)
+        if self.feature_selection_start < self.model_dev_start:
+            msg = (
+                f"feature_selection_start ({self.feature_selection_start}) "
+                f"must be >= model_dev_start ({self.model_dev_start})"
+            )
+            raise ValueError(msg)
+        if self.feature_selection_end > self.model_dev_end:
+            msg = (
+                f"feature_selection_end ({self.feature_selection_end}) must be <= model_dev_end ({self.model_dev_end})"
+            )
+            raise ValueError(msg)
+        return self
+
+    @classmethod
+    def default(cls) -> DataPartition:
+        """Return the standard project-level temporal partition.
+
+        Returns:
+            DataPartition with the following boundaries:
+                - Feature selection: 2020-01-01 to 2022-12-31
+                - Model development: 2020-01-01 to 2023-12-31
+                - Final holdout: 2024-01-01 onwards
+        """
+        return cls(
+            feature_selection_start=datetime(2020, 1, 1, tzinfo=UTC),
+            feature_selection_end=datetime(2023, 1, 1, tzinfo=UTC),
+            model_dev_start=datetime(2020, 1, 1, tzinfo=UTC),
+            model_dev_end=datetime(2024, 1, 1, tzinfo=UTC),
+            holdout_start=datetime(2024, 1, 1, tzinfo=UTC),
+        )
+
+    def filter_feature_selection(self, df: pl.DataFrame, timestamp_col: str) -> pl.DataFrame:
+        """Filter a DataFrame to the feature selection period.
+
+        Args:
+            df: Input Polars DataFrame.
+            timestamp_col: Name of the timestamp column to filter on.
+
+        Returns:
+            Filtered DataFrame with rows where ``start <= timestamp < end``.
+        """
+        return df.filter(
+            (pl.col(timestamp_col) >= self.feature_selection_start)
+            & (pl.col(timestamp_col) < self.feature_selection_end)
+        )
+
+    def filter_model_dev(self, df: pl.DataFrame, timestamp_col: str) -> pl.DataFrame:
+        """Filter a DataFrame to the model development period.
+
+        Args:
+            df: Input Polars DataFrame.
+            timestamp_col: Name of the timestamp column to filter on.
+
+        Returns:
+            Filtered DataFrame with rows where ``start <= timestamp < end``.
+        """
+        return df.filter(
+            (pl.col(timestamp_col) >= self.model_dev_start) & (pl.col(timestamp_col) < self.model_dev_end)
+        )
+
+    def filter_holdout(self, df: pl.DataFrame, timestamp_col: str) -> pl.DataFrame:
+        """Filter a DataFrame to the holdout period.
+
+        Args:
+            df: Input Polars DataFrame.
+            timestamp_col: Name of the timestamp column to filter on.
+
+        Returns:
+            Filtered DataFrame with rows where ``timestamp >= holdout_start``.
+        """
+        return df.filter(pl.col(timestamp_col) >= self.holdout_start)
+
+
+class SampleTier(Enum):
+    """Sample-size tier classification for bar types.
+
+    Determines which modelling techniques are appropriate given the
+    number of available samples.
+
+    Attributes:
+        A: >= tier_a_threshold samples. Full ML pipeline available.
+        B: Between tier_b_threshold and tier_a_threshold. Restricted to
+           simpler models with stronger regularisation.
+        C: < tier_b_threshold samples. Statistical profiling only;
+           ML modelling is unreliable.
+    """
+
+    A = "A"
+    B = "B"
+    C = "C"
+
+
+class TierConfig(BaseModel, frozen=True):
+    """Configuration for sample-size tier thresholds.
+
+    Attributes:
+        tier_a_threshold: Minimum sample count for Tier A (full ML pipeline).
+        tier_b_threshold: Minimum sample count for Tier B (restricted models).
+    """
+
+    tier_a_threshold: Annotated[
+        int,
+        PydanticField(default=2000, ge=1, description="Minimum samples for Tier A"),
+    ]
+
+    tier_b_threshold: Annotated[
+        int,
+        PydanticField(default=500, ge=1, description="Minimum samples for Tier B"),
+    ]
+
+    @model_validator(mode="after")
+    def _thresholds_ordered(self) -> Self:
+        """Ensure tier_a_threshold > tier_b_threshold.
+
+        Returns:
+            Validated instance.
+
+        Raises:
+            ValueError: If ``tier_a_threshold`` is not greater than ``tier_b_threshold``.
+        """
+        if self.tier_a_threshold <= self.tier_b_threshold:
+            msg: str = (
+                f"tier_a_threshold ({self.tier_a_threshold}) must be > tier_b_threshold ({self.tier_b_threshold})"
+            )
+            raise ValueError(msg)
+        return self
+
+
+class TierClassifier:
+    """Stateless classifier that assigns a SampleTier based on sample count.
+
+    Example:
+        >>> classifier = TierClassifier()
+        >>> classifier.classify(3000, TierConfig())
+        <SampleTier.A: 'A'>
+    """
+
+    def classify(self, n_samples: int, config: TierConfig) -> SampleTier:  # noqa: PLR6301
+        """Classify a sample count into a tier.
+
+        Args:
+            n_samples: Number of available samples.
+            config: Tier threshold configuration.
+
+        Returns:
+            SampleTier.A if n_samples > tier_a_threshold,
+            SampleTier.B if tier_b_threshold <= n_samples <= tier_a_threshold,
+            SampleTier.C otherwise.
+        """
+        if n_samples > config.tier_a_threshold:
+            return SampleTier.A
+        if n_samples >= config.tier_b_threshold:
+            return SampleTier.B
+        return SampleTier.C
+
+
+class StationarityTestResult(BaseModel, frozen=True):
+    """Per-feature stationarity test result from ADF and KPSS tests.
+
+    The joint interpretation of ADF (null: unit root) and KPSS
+    (null: stationary) determines the classification:
+
+    - **stationary**: ADF rejects AND KPSS fails to reject.
+    - **trend_stationary**: ADF rejects AND KPSS rejects.
+    - **unit_root**: ADF fails to reject AND KPSS rejects.
+    - **inconclusive**: Neither test rejects its null.
+
+    Attributes:
+        feature_name: Column name of the tested feature.
+        adf_statistic: ADF test statistic.
+        adf_pvalue: ADF test p-value.
+        kpss_statistic: KPSS test statistic.
+        kpss_pvalue: KPSS test p-value.
+        is_stationary: True when ADF rejects AND KPSS fails to reject.
+        classification: One of "stationary", "trend_stationary", "unit_root", "inconclusive".
+        suggested_transformation: Recommended transformation for non-stationary features.
+    """
+
+    feature_name: str
+    adf_statistic: float
+    adf_pvalue: Annotated[float, PydanticField(ge=0, le=1)]
+    kpss_statistic: float
+    kpss_pvalue: Annotated[float, PydanticField(ge=0, le=1)]
+    is_stationary: bool
+    classification: str
+    suggested_transformation: str | None
+
+
+class StationarityReport(BaseModel, frozen=True):
+    """Aggregate stationarity screening report for a single asset-bar combination.
+
+    Attributes:
+        results: Per-feature stationarity test results.
+        n_stationary: Count of features classified as stationary.
+        n_non_stationary: Count of features not classified as stationary.
+        asset: Asset symbol (e.g. "BTCUSDT").
+        bar_type: Bar type identifier (e.g. "dollar", "volume").
+    """
+
+    results: tuple[StationarityTestResult, ...]
+    n_stationary: int
+    n_non_stationary: int
+    asset: str
+    bar_type: str

--- a/src/tests/features/test_entities.py
+++ b/src/tests/features/test_entities.py
@@ -162,6 +162,13 @@ class TestFeatureValidationResult:
         result: FeatureValidationResult = _make_validation_result(group="volatility")
         assert result.group == "volatility"
 
+    def test_dc_mae_null_mean_accepts_nan(self) -> None:
+        """dc_mae_null_mean should accept NaN (DC-MAE is now an observed diagnostic only)."""
+        import math
+
+        result: FeatureValidationResult = _make_validation_result(dc_mae_null_mean=float("nan"))
+        assert math.isnan(result.dc_mae_null_mean)
+
 
 # ---------------------------------------------------------------------------
 # InteractionTestResult tests

--- a/src/tests/features/test_validation_helpers.py
+++ b/src/tests/features/test_validation_helpers.py
@@ -12,11 +12,13 @@ import pytest
 
 from src.app.features.application.validation import (
     apply_bh_correction,
+    block_permute,
     classify_feature_group,
     compute_dc_mae,
     compute_directional_accuracy,
     compute_empirical_pvalue,
     compute_mi_score,
+    compute_ridge_null_distribution,
     evaluate_single_feature_ridge,
 )
 
@@ -216,7 +218,12 @@ class TestEvaluateSingleFeatureRidge:
         rng: np.random.Generator = np.random.default_rng(_SEED)
         feature: np.ndarray[tuple[int], np.dtype[np.float64]] = rng.standard_normal(200)
         target: np.ndarray[tuple[int], np.dtype[np.float64]] = rng.standard_normal(200)
-        result: tuple[float, float] = evaluate_single_feature_ridge(feature, target, ridge_alpha=1.0)
+        result: tuple[float, float] = evaluate_single_feature_ridge(
+            feature,
+            target,
+            ridge_alpha=1.0,
+            train_fraction=0.7,
+        )
         assert isinstance(result, tuple)
         assert len(result) == 2
         da: float = result[0]
@@ -229,7 +236,7 @@ class TestEvaluateSingleFeatureRidge:
         rng: np.random.Generator = np.random.default_rng(_SEED + 1)
         feature: np.ndarray[tuple[int], np.dtype[np.float64]] = rng.standard_normal(200)
         target: np.ndarray[tuple[int], np.dtype[np.float64]] = rng.standard_normal(200)
-        da, _ = evaluate_single_feature_ridge(feature, target, ridge_alpha=1.0)
+        da, _ = evaluate_single_feature_ridge(feature, target, ridge_alpha=1.0, train_fraction=0.7)
         assert 0.0 <= da <= 1.0
 
     def test_ridge_perfect_linear_signal_high_da(self) -> None:
@@ -284,3 +291,123 @@ class TestClassifyFeatureGroup:
         """Empty feature_groups dict always returns 'other'."""
         result: str = classify_feature_group("anything", {})
         assert result == "other"
+
+
+class TestBlockPermute:
+    """Tests for the block_permute function."""
+
+    def test_block_permute_preserves_marginal_distribution(self) -> None:
+        """Block permutation must preserve the same set of values (marginal distribution)."""
+        rng: np.random.Generator = np.random.default_rng(_SEED)
+        target: np.ndarray[tuple[int], np.dtype[np.float64]] = np.arange(100, dtype=np.float64)
+        result: np.ndarray[tuple[int], np.dtype[np.float64]] = block_permute(target, block_size=10, rng=rng)
+        assert sorted(result.tolist()) == sorted(target.tolist())
+
+    def test_block_permute_preserves_length(self) -> None:
+        """Block permutation output must have the same length as input."""
+        rng: np.random.Generator = np.random.default_rng(_SEED)
+        target: np.ndarray[tuple[int], np.dtype[np.float64]] = np.arange(100, dtype=np.float64)
+        result: np.ndarray[tuple[int], np.dtype[np.float64]] = block_permute(target, block_size=10, rng=rng)
+        assert len(result) == len(target)
+
+    def test_block_permute_breaks_temporal_order(self) -> None:
+        """Block permutation should (usually) change element positions."""
+        rng: np.random.Generator = np.random.default_rng(_SEED)
+        target: np.ndarray[tuple[int], np.dtype[np.float64]] = np.arange(100, dtype=np.float64)
+        result: np.ndarray[tuple[int], np.dtype[np.float64]] = block_permute(target, block_size=10, rng=rng)
+        # With 10 blocks, it's very unlikely that the order is preserved
+        assert not np.array_equal(result, target)
+
+    def test_block_permute_preserves_within_block_order(self) -> None:
+        """Within each block, the relative order of elements should be preserved."""
+        rng: np.random.Generator = np.random.default_rng(_SEED)
+        target: np.ndarray[tuple[int], np.dtype[np.float64]] = np.arange(20, dtype=np.float64)
+        result: np.ndarray[tuple[int], np.dtype[np.float64]] = block_permute(target, block_size=5, rng=rng)
+        # Each contiguous group of 5 in the result should be a monotonically
+        # increasing sequence from the original (since original is 0..19)
+        for i in range(0, 20, 5):
+            block: np.ndarray[tuple[int], np.dtype[np.float64]] = result[i : i + 5]
+            # Check that the block is a contiguous range from the original
+            assert block[1] == block[0] + 1
+            assert block[2] == block[0] + 2
+            assert block[3] == block[0] + 3
+            assert block[4] == block[0] + 4
+
+    def test_block_permute_single_element_blocks(self) -> None:
+        """Block size 1 should still permute (equivalent to element-wise shuffle)."""
+        rng: np.random.Generator = np.random.default_rng(_SEED)
+        target: np.ndarray[tuple[int], np.dtype[np.float64]] = np.arange(50, dtype=np.float64)
+        result: np.ndarray[tuple[int], np.dtype[np.float64]] = block_permute(target, block_size=1, rng=rng)
+        assert len(result) == len(target)
+        assert sorted(result.tolist()) == sorted(target.tolist())
+
+    def test_block_permute_block_size_ge_length_returns_copy(self) -> None:
+        """When block_size >= len(target), return a copy of target (nothing to shuffle)."""
+        rng: np.random.Generator = np.random.default_rng(_SEED)
+        target: np.ndarray[tuple[int], np.dtype[np.float64]] = np.array([1.0, 2.0, 3.0])
+        result: np.ndarray[tuple[int], np.dtype[np.float64]] = block_permute(target, block_size=5, rng=rng)
+        assert np.array_equal(result, target)
+        # Must be a copy, not the same object
+        assert result is not target
+
+    def test_block_permute_uneven_blocks(self) -> None:
+        """When n is not divisible by block_size, the last block can be shorter."""
+        rng: np.random.Generator = np.random.default_rng(_SEED)
+        target: np.ndarray[tuple[int], np.dtype[np.float64]] = np.arange(13, dtype=np.float64)
+        result: np.ndarray[tuple[int], np.dtype[np.float64]] = block_permute(target, block_size=5, rng=rng)
+        assert len(result) == 13
+        assert sorted(result.tolist()) == sorted(target.tolist())
+
+
+class TestRidgeTrainRatioConfig:
+    """Tests for ridge_train_ratio config threading."""
+
+    def test_evaluate_ridge_respects_train_fraction(self) -> None:
+        """evaluate_single_feature_ridge with different train_fractions gives different results."""
+        rng: np.random.Generator = np.random.default_rng(_SEED + 10)
+        feature: np.ndarray[tuple[int], np.dtype[np.float64]] = rng.standard_normal(200)
+        target: np.ndarray[tuple[int], np.dtype[np.float64]] = feature + 0.1 * rng.standard_normal(200)
+        da_07: float
+        da_05: float
+        da_07, _ = evaluate_single_feature_ridge(feature, target, ridge_alpha=1.0, train_fraction=0.7)
+        da_05, _ = evaluate_single_feature_ridge(feature, target, ridge_alpha=1.0, train_fraction=0.5)
+        # Both should return valid DAs (they may or may not differ numerically)
+        assert 0.0 <= da_07 <= 1.0
+        assert 0.0 <= da_05 <= 1.0
+
+
+class TestRidgeNullDistributionReturnsDAOnly:
+    """Tests verifying compute_ridge_null_distribution returns DA-only array."""
+
+    def test_returns_1d_array(self) -> None:
+        """compute_ridge_null_distribution should return a 1-D DA null array."""
+        rng_data: np.random.Generator = np.random.default_rng(_SEED + 20)
+        feature: np.ndarray[tuple[int], np.dtype[np.float64]] = rng_data.standard_normal(200)
+        target: np.ndarray[tuple[int], np.dtype[np.float64]] = rng_data.standard_normal(200)
+        result: np.ndarray[tuple[int], np.dtype[np.float64]] = compute_ridge_null_distribution(
+            feature,
+            target,
+            n_permutations=10,
+            ridge_alpha=1.0,
+            random_seed=_SEED,
+            train_fraction=0.7,
+        )
+        assert isinstance(result, np.ndarray)
+        assert result.ndim == 1
+        assert len(result) == 10
+
+    def test_da_nulls_in_valid_range(self) -> None:
+        """All DA null values should be in [0, 1]."""
+        rng_data: np.random.Generator = np.random.default_rng(_SEED + 30)
+        feature: np.ndarray[tuple[int], np.dtype[np.float64]] = rng_data.standard_normal(200)
+        target: np.ndarray[tuple[int], np.dtype[np.float64]] = rng_data.standard_normal(200)
+        result: np.ndarray[tuple[int], np.dtype[np.float64]] = compute_ridge_null_distribution(
+            feature,
+            target,
+            n_permutations=20,
+            ridge_alpha=1.0,
+            random_seed=_SEED,
+            train_fraction=0.7,
+        )
+        assert np.all(result >= 0.0)
+        assert np.all(result <= 1.0)

--- a/src/tests/profiling/__init__.py
+++ b/src/tests/profiling/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the profiling module."""

--- a/src/tests/profiling/conftest.py
+++ b/src/tests/profiling/conftest.py
@@ -1,0 +1,72 @@
+"""Shared fixtures and factory functions for profiling module tests.
+
+Provides synthetic data generators for stationarity testing and
+reusable configuration fixtures.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd  # type: ignore[import-untyped]
+
+
+def make_stationary_series(
+    n: int = 500,
+    seed: int = 42,
+) -> np.ndarray[tuple[int], np.dtype[np.float64]]:
+    """Generate a stationary (white noise) series.
+
+    Args:
+        n: Number of observations.
+        seed: Random seed for reproducibility.
+
+    Returns:
+        1-D array of i.i.d. standard normal values.
+    """
+    rng: np.random.Generator = np.random.default_rng(seed)
+    return rng.standard_normal(n)
+
+
+def make_unit_root_series(
+    n: int = 500,
+    seed: int = 42,
+) -> np.ndarray[tuple[int], np.dtype[np.float64]]:
+    """Generate a unit root (random walk) series.
+
+    Args:
+        n: Number of observations.
+        seed: Random seed for reproducibility.
+
+    Returns:
+        1-D array of cumulative sum of standard normal values.
+    """
+    rng: np.random.Generator = np.random.default_rng(seed)
+    steps: np.ndarray[tuple[int], np.dtype[np.float64]] = rng.standard_normal(n)
+    return np.cumsum(steps)
+
+
+def make_stationarity_test_df(
+    n: int = 500,
+    seed: int = 42,
+) -> tuple[pd.DataFrame, list[str]]:
+    """Build a Pandas DataFrame with known stationary and non-stationary features.
+
+    Args:
+        n: Number of observations.
+        seed: Random seed for reproducibility.
+
+    Returns:
+        Tuple of (DataFrame, list of feature column names).
+        Contains 'stationary_feat' (white noise) and 'unit_root_feat' (random walk).
+    """
+    stationary: np.ndarray[tuple[int], np.dtype[np.float64]] = make_stationary_series(n, seed)
+    unit_root: np.ndarray[tuple[int], np.dtype[np.float64]] = make_unit_root_series(n, seed + 1)
+
+    df: pd.DataFrame = pd.DataFrame(
+        {
+            "stationary_feat": stationary,
+            "unit_root_feat": unit_root,
+        }
+    )
+    feature_names: list[str] = ["stationary_feat", "unit_root_feat"]
+    return df, feature_names

--- a/src/tests/profiling/test_data_partition.py
+++ b/src/tests/profiling/test_data_partition.py
@@ -1,0 +1,185 @@
+"""Tests for DataPartition construction, validation, and filtering."""
+
+from __future__ import annotations
+
+from datetime import datetime, UTC
+
+import polars as pl
+import pytest
+
+from src.app.profiling.domain.value_objects import DataPartition
+
+
+class TestDataPartitionConstruction:
+    """Tests for DataPartition construction and default()."""
+
+    def test_default_partition_creates_valid_instance(self) -> None:
+        """DataPartition.default() must return a valid instance."""
+        partition = DataPartition.default()
+        assert partition.feature_selection_start == datetime(2020, 1, 1, tzinfo=UTC)
+        assert partition.feature_selection_end == datetime(2023, 1, 1, tzinfo=UTC)
+        assert partition.model_dev_start == datetime(2020, 1, 1, tzinfo=UTC)
+        assert partition.model_dev_end == datetime(2024, 1, 1, tzinfo=UTC)
+        assert partition.holdout_start == datetime(2024, 1, 1, tzinfo=UTC)
+
+    def test_custom_partition_accepts_valid_boundaries(self) -> None:
+        """Custom valid boundaries should be accepted."""
+        partition = DataPartition(
+            feature_selection_start=datetime(2021, 1, 1, tzinfo=UTC),
+            feature_selection_end=datetime(2022, 1, 1, tzinfo=UTC),
+            model_dev_start=datetime(2020, 1, 1, tzinfo=UTC),
+            model_dev_end=datetime(2023, 1, 1, tzinfo=UTC),
+            holdout_start=datetime(2023, 1, 1, tzinfo=UTC),
+        )
+        assert partition.feature_selection_start == datetime(2021, 1, 1, tzinfo=UTC)
+
+    def test_partition_is_frozen(self) -> None:
+        """DataPartition instances must be immutable."""
+        from pydantic import ValidationError
+
+        partition = DataPartition.default()
+        with pytest.raises(ValidationError):
+            partition.holdout_start = datetime(2025, 1, 1, tzinfo=UTC)  # type: ignore[misc]
+
+
+class TestDataPartitionValidation:
+    """Tests for DataPartition validation rules."""
+
+    def test_feature_selection_start_ge_end_raises(self) -> None:
+        """feature_selection_start >= feature_selection_end must raise ValueError."""
+        with pytest.raises(ValueError, match="feature_selection_start"):
+            DataPartition(
+                feature_selection_start=datetime(2023, 1, 1, tzinfo=UTC),
+                feature_selection_end=datetime(2022, 1, 1, tzinfo=UTC),
+                model_dev_start=datetime(2020, 1, 1, tzinfo=UTC),
+                model_dev_end=datetime(2024, 1, 1, tzinfo=UTC),
+                holdout_start=datetime(2024, 1, 1, tzinfo=UTC),
+            )
+
+    def test_model_dev_start_ge_end_raises(self) -> None:
+        """model_dev_start >= model_dev_end must raise ValueError."""
+        with pytest.raises(ValueError, match="model_dev_start"):
+            DataPartition(
+                feature_selection_start=datetime(2020, 1, 1, tzinfo=UTC),
+                feature_selection_end=datetime(2022, 1, 1, tzinfo=UTC),
+                model_dev_start=datetime(2024, 1, 1, tzinfo=UTC),
+                model_dev_end=datetime(2023, 1, 1, tzinfo=UTC),
+                holdout_start=datetime(2025, 1, 1, tzinfo=UTC),
+            )
+
+    def test_holdout_before_model_dev_end_raises(self) -> None:
+        """holdout_start < model_dev_end must raise ValueError."""
+        with pytest.raises(ValueError, match="holdout_start"):
+            DataPartition(
+                feature_selection_start=datetime(2020, 1, 1, tzinfo=UTC),
+                feature_selection_end=datetime(2022, 1, 1, tzinfo=UTC),
+                model_dev_start=datetime(2020, 1, 1, tzinfo=UTC),
+                model_dev_end=datetime(2024, 1, 1, tzinfo=UTC),
+                holdout_start=datetime(2023, 6, 1, tzinfo=UTC),
+            )
+
+    def test_feature_selection_before_model_dev_start_raises(self) -> None:
+        """feature_selection_start < model_dev_start must raise ValueError."""
+        with pytest.raises(ValueError, match="feature_selection_start"):
+            DataPartition(
+                feature_selection_start=datetime(2019, 1, 1, tzinfo=UTC),
+                feature_selection_end=datetime(2022, 1, 1, tzinfo=UTC),
+                model_dev_start=datetime(2020, 1, 1, tzinfo=UTC),
+                model_dev_end=datetime(2024, 1, 1, tzinfo=UTC),
+                holdout_start=datetime(2024, 1, 1, tzinfo=UTC),
+            )
+
+    def test_feature_selection_end_after_model_dev_end_raises(self) -> None:
+        """feature_selection_end > model_dev_end must raise ValueError."""
+        with pytest.raises(ValueError, match="feature_selection_end"):
+            DataPartition(
+                feature_selection_start=datetime(2020, 1, 1, tzinfo=UTC),
+                feature_selection_end=datetime(2025, 1, 1, tzinfo=UTC),
+                model_dev_start=datetime(2020, 1, 1, tzinfo=UTC),
+                model_dev_end=datetime(2024, 1, 1, tzinfo=UTC),
+                holdout_start=datetime(2024, 1, 1, tzinfo=UTC),
+            )
+
+
+class TestDataPartitionFiltering:
+    """Tests for DataPartition filter_* methods."""
+
+    def test_filter_feature_selection(self) -> None:
+        """filter_feature_selection keeps only rows in [start, end)."""
+        partition = DataPartition.default()
+        df = pl.DataFrame(
+            {
+                "timestamp": [
+                    datetime(2019, 12, 31, tzinfo=UTC),
+                    datetime(2020, 1, 1, tzinfo=UTC),
+                    datetime(2022, 6, 15, tzinfo=UTC),
+                    datetime(2023, 1, 1, tzinfo=UTC),
+                    datetime(2024, 1, 1, tzinfo=UTC),
+                ],
+                "value": [1, 2, 3, 4, 5],
+            }
+        )
+        result = partition.filter_feature_selection(df, "timestamp")
+        assert result.height == 2
+        assert result["value"].to_list() == [2, 3]
+
+    def test_filter_model_dev(self) -> None:
+        """filter_model_dev keeps only rows in [start, end)."""
+        partition = DataPartition.default()
+        df = pl.DataFrame(
+            {
+                "timestamp": [
+                    datetime(2019, 12, 31, tzinfo=UTC),
+                    datetime(2020, 1, 1, tzinfo=UTC),
+                    datetime(2023, 6, 15, tzinfo=UTC),
+                    datetime(2024, 1, 1, tzinfo=UTC),
+                ],
+                "value": [1, 2, 3, 4],
+            }
+        )
+        result = partition.filter_model_dev(df, "timestamp")
+        assert result.height == 2
+        assert result["value"].to_list() == [2, 3]
+
+    def test_filter_holdout(self) -> None:
+        """filter_holdout keeps only rows where timestamp >= holdout_start."""
+        partition = DataPartition.default()
+        df = pl.DataFrame(
+            {
+                "timestamp": [
+                    datetime(2023, 12, 31, tzinfo=UTC),
+                    datetime(2024, 1, 1, tzinfo=UTC),
+                    datetime(2024, 6, 15, tzinfo=UTC),
+                ],
+                "value": [1, 2, 3],
+            }
+        )
+        result = partition.filter_holdout(df, "timestamp")
+        assert result.height == 2
+        assert result["value"].to_list() == [2, 3]
+
+    def test_filter_on_empty_dataframe(self) -> None:
+        """Filtering an empty DataFrame returns an empty DataFrame."""
+        partition = DataPartition.default()
+        df = pl.DataFrame(
+            {
+                "timestamp": pl.Series([], dtype=pl.Datetime("us", "UTC")),
+                "value": pl.Series([], dtype=pl.Float64),
+            }
+        )
+        assert partition.filter_feature_selection(df, "timestamp").height == 0
+        assert partition.filter_model_dev(df, "timestamp").height == 0
+        assert partition.filter_holdout(df, "timestamp").height == 0
+
+    def test_filter_no_matching_rows(self) -> None:
+        """Filtering when no rows match returns an empty DataFrame."""
+        partition = DataPartition.default()
+        df = pl.DataFrame(
+            {
+                "timestamp": [datetime(2019, 1, 1, tzinfo=UTC)],
+                "value": [42],
+            }
+        )
+        assert partition.filter_feature_selection(df, "timestamp").height == 0
+        assert partition.filter_model_dev(df, "timestamp").height == 0
+        assert partition.filter_holdout(df, "timestamp").height == 0

--- a/src/tests/profiling/test_stationarity.py
+++ b/src/tests/profiling/test_stationarity.py
@@ -1,0 +1,231 @@
+"""Tests for StationarityScreener against known synthetic data.
+
+Uses white noise (stationary) and random walk (unit root) series to
+verify correct classification by the joint ADF + KPSS test.
+"""
+
+from __future__ import annotations
+
+import pandas as pd  # type: ignore[import-untyped]
+import pytest
+
+from src.app.profiling.application.stationarity import StationarityScreener
+from src.app.profiling.domain.value_objects import (
+    StationarityReport,
+    StationarityTestResult,
+)
+
+from src.tests.profiling.conftest import (
+    make_stationarity_test_df,
+    make_stationary_series,
+    make_unit_root_series,
+)
+
+
+class TestStationarityTestResult:
+    """Tests for StationarityTestResult construction."""
+
+    def test_valid_result_construction(self) -> None:
+        """A valid StationarityTestResult should be constructable."""
+        result = StationarityTestResult(
+            feature_name="test_feat",
+            adf_statistic=-3.5,
+            adf_pvalue=0.01,
+            kpss_statistic=0.2,
+            kpss_pvalue=0.1,
+            is_stationary=True,
+            classification="stationary",
+            suggested_transformation=None,
+        )
+        assert result.feature_name == "test_feat"
+        assert result.is_stationary is True
+
+    def test_result_is_frozen(self) -> None:
+        """StationarityTestResult must be immutable."""
+        from pydantic import ValidationError
+
+        result = StationarityTestResult(
+            feature_name="test_feat",
+            adf_statistic=-3.5,
+            adf_pvalue=0.01,
+            kpss_statistic=0.2,
+            kpss_pvalue=0.1,
+            is_stationary=True,
+            classification="stationary",
+            suggested_transformation=None,
+        )
+        with pytest.raises(ValidationError):
+            result.is_stationary = False  # type: ignore[misc]
+
+
+class TestStationarityReport:
+    """Tests for StationarityReport construction."""
+
+    def test_report_construction(self) -> None:
+        """A valid StationarityReport should be constructable."""
+        result = StationarityTestResult(
+            feature_name="feat1",
+            adf_statistic=-4.0,
+            adf_pvalue=0.001,
+            kpss_statistic=0.1,
+            kpss_pvalue=0.5,
+            is_stationary=True,
+            classification="stationary",
+            suggested_transformation=None,
+        )
+        report = StationarityReport(
+            results=(result,),
+            n_stationary=1,
+            n_non_stationary=0,
+            asset="BTCUSDT",
+            bar_type="dollar",
+        )
+        assert report.n_stationary == 1
+        assert len(report.results) == 1
+
+
+class TestStationarityScreener:
+    """Integration tests for StationarityScreener.screen."""
+
+    def test_white_noise_classified_as_stationary(self) -> None:
+        """White noise series should be classified as stationary."""
+        series = make_stationary_series(1000, seed=42)
+        df = pd.DataFrame({"white_noise": series})
+        screener = StationarityScreener()
+        report = screener.screen(
+            df,
+            feature_names=["white_noise"],
+            asset="BTCUSDT",
+            bar_type="dollar",
+        )
+        assert report.n_stationary == 1
+        assert report.results[0].classification == "stationary"
+        assert report.results[0].is_stationary is True
+
+    def test_random_walk_classified_as_non_stationary(self) -> None:
+        """Random walk series should be classified as unit_root."""
+        series = make_unit_root_series(1000, seed=42)
+        df = pd.DataFrame({"random_walk": series})
+        screener = StationarityScreener()
+        report = screener.screen(
+            df,
+            feature_names=["random_walk"],
+            asset="BTCUSDT",
+            bar_type="dollar",
+        )
+        assert report.results[0].is_stationary is False
+        assert report.results[0].classification in {"unit_root", "trend_stationary"}
+
+    def test_mixed_features_counted_correctly(self) -> None:
+        """Report counts should match the number of stationary/non-stationary features."""
+        df, feature_names = make_stationarity_test_df(1000, seed=42)
+        screener = StationarityScreener()
+        report = screener.screen(
+            df,
+            feature_names=feature_names,
+            asset="ETHUSDT",
+            bar_type="volume",
+        )
+        assert report.n_stationary + report.n_non_stationary == len(feature_names)
+        assert len(report.results) == len(feature_names)
+
+    def test_report_metadata(self) -> None:
+        """Report should carry asset and bar_type metadata."""
+        df, feature_names = make_stationarity_test_df(500, seed=10)
+        screener = StationarityScreener()
+        report = screener.screen(
+            df,
+            feature_names=feature_names,
+            asset="SOLUSDT",
+            bar_type="dollar_imbalance",
+        )
+        assert report.asset == "SOLUSDT"
+        assert report.bar_type == "dollar_imbalance"
+
+    def test_nan_in_feature_raises_value_error(self) -> None:
+        """NaN in a feature column should raise ValueError."""
+        df = pd.DataFrame({"bad_feat": [1.0, 2.0, float("nan"), 4.0]})
+        screener = StationarityScreener()
+        with pytest.raises(ValueError, match="NaN or inf"):
+            screener.screen(df, feature_names=["bad_feat"], asset="X", bar_type="Y")
+
+    def test_inf_in_feature_raises_value_error(self) -> None:
+        """Inf in a feature column should raise ValueError."""
+        df = pd.DataFrame({"bad_feat": [1.0, 2.0, float("inf"), 4.0]})
+        screener = StationarityScreener()
+        with pytest.raises(ValueError, match="NaN or inf"):
+            screener.screen(df, feature_names=["bad_feat"], asset="X", bar_type="Y")
+
+    def test_suggested_transformation_atr_prefix(self) -> None:
+        """Non-stationary features with 'atr_' prefix should suggest 'pct_atr'."""
+        series = make_unit_root_series(1000, seed=99)
+        df = pd.DataFrame({"atr_14": series})
+        screener = StationarityScreener()
+        report = screener.screen(df, feature_names=["atr_14"], asset="X", bar_type="Y")
+        if not report.results[0].is_stationary:
+            assert report.results[0].suggested_transformation == "pct_atr"
+
+    def test_suggested_transformation_amihud_prefix(self) -> None:
+        """Non-stationary features with 'amihud_' prefix should suggest 'rolling_zscore'."""
+        series = make_unit_root_series(1000, seed=100)
+        df = pd.DataFrame({"amihud_24": series})
+        screener = StationarityScreener()
+        report = screener.screen(df, feature_names=["amihud_24"], asset="X", bar_type="Y")
+        if not report.results[0].is_stationary:
+            assert report.results[0].suggested_transformation == "rolling_zscore"
+
+    def test_suggested_transformation_hurst_prefix(self) -> None:
+        """Non-stationary features with 'hurst_' prefix should suggest 'first_difference'."""
+        series = make_unit_root_series(1000, seed=101)
+        df = pd.DataFrame({"hurst_100": series})
+        screener = StationarityScreener()
+        report = screener.screen(df, feature_names=["hurst_100"], asset="X", bar_type="Y")
+        if not report.results[0].is_stationary:
+            assert report.results[0].suggested_transformation == "first_difference"
+
+    def test_no_transformation_for_stationary_feature(self) -> None:
+        """Stationary features should have no suggested transformation."""
+        series = make_stationary_series(1000, seed=200)
+        df = pd.DataFrame({"stationary": series})
+        screener = StationarityScreener()
+        report = screener.screen(df, feature_names=["stationary"], asset="X", bar_type="Y")
+        if report.results[0].is_stationary:
+            assert report.results[0].suggested_transformation is None
+
+    def test_no_transformation_for_unknown_prefix(self) -> None:
+        """Non-stationary features with unknown prefix should have no suggestion."""
+        series = make_unit_root_series(1000, seed=300)
+        df = pd.DataFrame({"unknown_feat": series})
+        screener = StationarityScreener()
+        report = screener.screen(df, feature_names=["unknown_feat"], asset="X", bar_type="Y")
+        if not report.results[0].is_stationary:
+            assert report.results[0].suggested_transformation is None
+
+    def test_adf_pvalue_in_range(self) -> None:
+        """ADF p-value should always be in [0, 1]."""
+        series = make_stationary_series(500, seed=42)
+        df = pd.DataFrame({"feat": series})
+        screener = StationarityScreener()
+        report = screener.screen(df, feature_names=["feat"], asset="X", bar_type="Y")
+        assert 0.0 <= report.results[0].adf_pvalue <= 1.0
+
+    def test_kpss_pvalue_in_range(self) -> None:
+        """KPSS p-value should always be in [0, 1] (clamped)."""
+        series = make_stationary_series(500, seed=42)
+        df = pd.DataFrame({"feat": series})
+        screener = StationarityScreener()
+        report = screener.screen(df, feature_names=["feat"], asset="X", bar_type="Y")
+        assert 0.0 <= report.results[0].kpss_pvalue <= 1.0
+
+    def test_custom_alpha(self) -> None:
+        """Custom alpha should be respected without errors."""
+        df, feature_names = make_stationarity_test_df(500, seed=42)
+        screener = StationarityScreener()
+        report = screener.screen(
+            df,
+            feature_names=feature_names,
+            asset="BTCUSDT",
+            bar_type="dollar",
+            alpha=0.01,
+        )
+        assert len(report.results) == 2

--- a/src/tests/profiling/test_tier_classification.py
+++ b/src/tests/profiling/test_tier_classification.py
@@ -1,0 +1,106 @@
+"""Tests for SampleTier enum, TierConfig, and TierClassifier."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.app.profiling.domain.value_objects import SampleTier, TierClassifier, TierConfig
+
+
+class TestSampleTier:
+    """Tests for the SampleTier enum."""
+
+    def test_tier_values(self) -> None:
+        """SampleTier must have exactly three members: A, B, C."""
+        assert SampleTier.A.value == "A"
+        assert SampleTier.B.value == "B"
+        assert SampleTier.C.value == "C"
+        assert len(SampleTier) == 3
+
+
+class TestTierConfig:
+    """Tests for TierConfig validation."""
+
+    def test_default_config(self) -> None:
+        """Default TierConfig must have tier_a=2000, tier_b=500."""
+        config = TierConfig()
+        assert config.tier_a_threshold == 2000
+        assert config.tier_b_threshold == 500
+
+    def test_custom_config(self) -> None:
+        """Custom thresholds should be accepted when a > b."""
+        config = TierConfig(tier_a_threshold=5000, tier_b_threshold=1000)
+        assert config.tier_a_threshold == 5000
+        assert config.tier_b_threshold == 1000
+
+    def test_tier_a_le_tier_b_raises(self) -> None:
+        """tier_a_threshold <= tier_b_threshold must raise ValueError."""
+        with pytest.raises(ValueError, match="tier_a_threshold"):
+            TierConfig(tier_a_threshold=500, tier_b_threshold=500)
+
+    def test_tier_a_lt_tier_b_raises(self) -> None:
+        """tier_a_threshold < tier_b_threshold must raise ValueError."""
+        with pytest.raises(ValueError, match="tier_a_threshold"):
+            TierConfig(tier_a_threshold=100, tier_b_threshold=500)
+
+    def test_config_is_frozen(self) -> None:
+        """TierConfig must be immutable."""
+        from pydantic import ValidationError
+
+        config = TierConfig()
+        with pytest.raises(ValidationError):
+            config.tier_a_threshold = 3000  # type: ignore[misc]
+
+
+class TestTierClassifier:
+    """Tests for TierClassifier.classify."""
+
+    def test_tier_a_above_threshold(self) -> None:
+        """Samples above tier_a_threshold should classify as Tier A."""
+        classifier = TierClassifier()
+        config = TierConfig()
+        assert classifier.classify(5000, config) == SampleTier.A
+
+    def test_tier_a_at_boundary(self) -> None:
+        """Exactly tier_a_threshold should classify as Tier B (not >)."""
+        classifier = TierClassifier()
+        config = TierConfig()
+        assert classifier.classify(2000, config) == SampleTier.B
+
+    def test_tier_a_just_above(self) -> None:
+        """One above tier_a_threshold should classify as Tier A."""
+        classifier = TierClassifier()
+        config = TierConfig()
+        assert classifier.classify(2001, config) == SampleTier.A
+
+    def test_tier_b_middle(self) -> None:
+        """Samples between thresholds should classify as Tier B."""
+        classifier = TierClassifier()
+        config = TierConfig()
+        assert classifier.classify(1000, config) == SampleTier.B
+
+    def test_tier_b_at_lower_boundary(self) -> None:
+        """Exactly tier_b_threshold should classify as Tier B."""
+        classifier = TierClassifier()
+        config = TierConfig()
+        assert classifier.classify(500, config) == SampleTier.B
+
+    def test_tier_c_below_b_threshold(self) -> None:
+        """Samples below tier_b_threshold should classify as Tier C."""
+        classifier = TierClassifier()
+        config = TierConfig()
+        assert classifier.classify(499, config) == SampleTier.C
+
+    def test_tier_c_zero_samples(self) -> None:
+        """Zero samples should classify as Tier C."""
+        classifier = TierClassifier()
+        config = TierConfig()
+        assert classifier.classify(0, config) == SampleTier.C
+
+    def test_custom_thresholds(self) -> None:
+        """Classification with custom thresholds should respect new boundaries."""
+        classifier = TierClassifier()
+        config = TierConfig(tier_a_threshold=100, tier_b_threshold=10)
+        assert classifier.classify(200, config) == SampleTier.A
+        assert classifier.classify(50, config) == SampleTier.B
+        assert classifier.classify(5, config) == SampleTier.C

--- a/uv.lock
+++ b/uv.lock
@@ -128,6 +128,27 @@ wheels = [
 ]
 
 [[package]]
+name = "arch"
+version = "8.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "scipy" },
+    { name = "statsmodels" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/50/f8be4b21db5eb0490aef82b592d105baac957f601805ee7fe5b9182405b2/arch-8.0.0.tar.gz", hash = "sha256:5e9895c2354b9475aff50797ff2191dc64dc5f79602baf0c9321310fb864b637", size = 872623, upload-time = "2025-10-21T08:55:52.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/37/8d9ec002ec3e750f3ea2af42b67a1e3cf3a82523b556fd8d10d1f34a085a/arch-8.0.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:8015f7bdcc14800dc2dc2acb01dffebddebf587df4aa27f62671e809ccfdefb1", size = 940799, upload-time = "2025-10-21T08:49:28.848Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c8/533ad2ef4277d2f6c95e8038088de2d80c6a41137c7d23e00b08425e2c39/arch-8.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a5a2ee20c5a0d88eda12894d8fbb8320b7bfe3436c2e40fa16da918db54eb5b4", size = 931745, upload-time = "2025-10-21T08:50:02.936Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8e/27bf8ef574c507fd984283acd8b33ff066c2ee4beea4b8af9eada23a20f4/arch-8.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:82113ee290afac972f73ad6f61b4b4ebd57bf9a288c2df163f9b2bc1874f89f3", size = 967633, upload-time = "2025-10-21T09:25:15.477Z" },
+    { url = "https://files.pythonhosted.org/packages/22/11/8a3b956a532b26fe4f325d9829b09eba725eb25a3e89d568673e2015beca/arch-8.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:563bea8e594f712a38ec2186f6dcd0d55a73f1c203bd228958cad495d9d471f1", size = 983273, upload-time = "2025-10-21T09:25:17.695Z" },
+    { url = "https://files.pythonhosted.org/packages/95/99/40ca7262d2cc5d74a7b8be10e8a254e0063969edb50959c489bad8d2adb4/arch-8.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:119766cdb3ac9ebdad4077dcf8238fb2a4554ba3c6503bd4431161f43923357e", size = 985658, upload-time = "2025-10-21T09:25:19.375Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/d1/14d3dab7283ea68a4e2d17be62d854af6df7e3d6f1b998a87d5be3ed8aed/arch-8.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:4849380bb831a1dc09891cd424f6623f163bde2403c66e376f9d0b5f8c1791c5", size = 934414, upload-time = "2025-10-21T08:44:28.636Z" },
+]
+
+[[package]]
 name = "argon2-cffi"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2791,6 +2812,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },
+    { name = "arch" },
     { name = "bokeh" },
     { name = "duckdb" },
     { name = "duckdb-engine" },
@@ -2829,6 +2851,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
+    { name = "arch", specifier = ">=8.0.0" },
     { name = "bokeh", specifier = ">=3.9.0" },
     { name = "duckdb", specifier = ">=1.4.4" },
     { name = "duckdb-engine", specifier = ">=0.17.0" },


### PR DESCRIPTION
## Summary

- **5pre.1 — DataPartition**: Authoritative temporal partition value object defining feature selection (2020–2022), model development (2020–2023), and holdout (2024+) boundaries. Includes Polars `filter_*` methods with start-inclusive/end-exclusive semantics.
- **5pre.2 — arch package**: Installed `arch==8.0.0` (Python 3.14 compatible) for future GARCH modelling.
- **5pre.3 — Validation hardening**: Three fixes to the Phase 4D pipeline:
  - Moved `ridge_train_ratio` to config (was a magic 0.7 default)
  - Added `block_permute()` for null distributions — preserves within-block autocorrelation, producing more conservative nulls for serially dependent targets
  - Removed DC-MAE null distribution waste — `dc_mae_null_mean` is now `NaN` (DC-MAE kept as observed diagnostic only)
- **5pre.4 — StationarityScreener**: Joint ADF + KPSS testing classifying features as stationary/trend_stationary/unit_root/inconclusive. Suggests transformations (`pct_atr`, `rolling_zscore`, `first_difference`) for known non-stationary feature families.
- **5pre.5 — SampleTier**: Enum (A/B/C) with TierClassifier for sample-size-aware model selection decisions.

## Test plan

- [x] 44 new profiling tests (DataPartition, TierClassifier, StationarityScreener)
- [x] 10 new validation tests (block_permute, ridge_train_ratio config, DA-only null distribution)
- [x] All 717 tests pass (`uv run pytest src/tests/ -q`)
- [x] All pre-commit hooks pass (ruff format + ruff lint + pyright)
- [x] Existing 195 features tests unbroken by validation.py changes

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)