### PR TITLE
feat(profiling): add Phase 5A return distribution analysis (#39)

### DIFF
--- a/src/app/profiling/application/distribution.py
+++ b/src/app/profiling/application/distribution.py
@@ -1,0 +1,333 @@
+"""Return distribution profiling via Jarque-Bera, Student-t MLE fitting, and AIC/BIC comparison.
+
+Uses the ML-research path (Pandas / NumPy / SciPy) per CLAUDE.md.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import NamedTuple
+
+import numpy as np
+import pandas as pd  # type: ignore[import-untyped]
+from loguru import logger
+from scipy import stats  # type: ignore[import-untyped]
+
+from src.app.profiling.domain.value_objects import (
+    DistributionConfig,
+    DistributionProfile,
+    SampleTier,
+)
+
+
+# ---------------------------------------------------------------------------
+# Number of free parameters for AIC / BIC computation
+# ---------------------------------------------------------------------------
+
+_N_PARAMS_NORMAL: int = 2  # mu, sigma
+_N_PARAMS_STUDENT_T: int = 3  # nu, loc, scale
+
+
+class _DescriptiveStats(NamedTuple):
+    """Container for descriptive statistics computed from a return series."""
+
+    mean_return: float
+    std_return: float
+    skewness: float
+    excess_kurtosis: float
+
+
+class _JBResult(NamedTuple):
+    """Container for Jarque-Bera test results."""
+
+    jb_stat: float
+    jb_pvalue: float
+    is_normal: bool
+
+
+class _FitResult(NamedTuple):
+    """Container for Student-t MLE fit and model comparison results."""
+
+    student_t_nu: float
+    student_t_loc: float
+    student_t_scale: float
+    aic_normal: float
+    aic_student_t: float
+    bic_normal: float
+    bic_student_t: float
+    best_fit: str
+    ks_statistic: float
+
+
+def _safe_float(val: float, default: float = 0.0) -> float:
+    """Replace NaN / Inf with *default*.
+
+    Args:
+        val: Value to sanitise.
+        default: Fallback when ``val`` is NaN or Inf.
+
+    Returns:
+        Sanitised float.
+    """
+    if math.isnan(val) or math.isinf(val):
+        return default
+    return val
+
+
+def _compute_aic(k: int, log_likelihood: float) -> float:
+    """Compute Akaike Information Criterion.
+
+    ``AIC = 2k - 2 * log_likelihood``
+
+    Args:
+        k: Number of free parameters.
+        log_likelihood: Maximised log-likelihood.
+
+    Returns:
+        AIC value (lower is better).
+    """
+    return 2.0 * k - 2.0 * log_likelihood
+
+
+def _compute_bic(k: int, n: int, log_likelihood: float) -> float:
+    """Compute Bayesian Information Criterion.
+
+    ``BIC = k * ln(n) - 2 * log_likelihood``
+
+    Args:
+        k: Number of free parameters.
+        n: Number of observations.
+        log_likelihood: Maximised log-likelihood.
+
+    Returns:
+        BIC value (lower is better).
+    """
+    return k * math.log(n) - 2.0 * log_likelihood
+
+
+def _compute_descriptive_stats(returns: pd.Series, n: int) -> _DescriptiveStats:  # type: ignore[type-arg]
+    """Compute mean, std, skewness, and excess kurtosis from a return series.
+
+    Args:
+        returns: Pandas Series of log returns.
+        n: Number of observations (avoids recomputation).
+
+    Returns:
+        Container with descriptive statistics.
+    """
+    mean_return: float = _safe_float(float(returns.mean())) if n > 0 else 0.0
+    std_return: float = _safe_float(float(returns.std())) if n > 0 else 0.0
+    skewness: float = _safe_float(float(stats.skew(returns))) if n > 0 else 0.0
+    excess_kurtosis: float = _safe_float(float(stats.kurtosis(returns, fisher=True))) if n > 0 else 0.0
+    return _DescriptiveStats(mean_return, std_return, skewness, excess_kurtosis)
+
+
+def _compute_jb_test(
+    returns: pd.Series,  # type: ignore[type-arg]
+    n: int,
+    std_return: float,
+    config: DistributionConfig,
+) -> _JBResult:
+    """Run the Jarque-Bera normality test.
+
+    Args:
+        returns: Pandas Series of log returns.
+        n: Number of observations.
+        std_return: Standard deviation (skip test if zero).
+        config: Configuration with alpha and min-sample thresholds.
+
+    Returns:
+        Container with JB stat, p-value, and normality decision.
+    """
+    if n >= config.min_samples_jb and std_return > 0:
+        jb_raw: object = stats.jarque_bera(returns)
+        jb_stat_raw: float = float(jb_raw[0])  # type: ignore[index]
+        jb_pvalue_raw: float = float(jb_raw[1])  # type: ignore[index]
+        jb_stat: float = _safe_float(jb_stat_raw)
+        jb_pvalue: float = _safe_float(jb_pvalue_raw, default=1.0)
+    else:
+        jb_stat = 0.0
+        jb_pvalue = 1.0
+
+    is_normal: bool = jb_pvalue >= config.jb_alpha
+    return _JBResult(jb_stat, jb_pvalue, is_normal)
+
+
+def _fit_distributions(
+    data: np.ndarray[tuple[int], np.dtype[np.float64]],
+    n: int,
+) -> _FitResult:
+    """Fit Normal and Student-t distributions, compute AIC/BIC and KS statistic.
+
+    Args:
+        data: 1-D NumPy array of return observations.
+        n: Number of observations.
+
+    Returns:
+        Container with all fitting and model-comparison results.
+    """
+    # Student-t MLE fit
+    nu_fit: float
+    loc_fit: float
+    scale_fit: float
+    nu_fit, loc_fit, scale_fit = stats.t.fit(data)  # type: ignore[no-untyped-call]
+
+    # Normal MLE fit (analytical)
+    mu_fit: float = float(np.mean(data))
+    sigma_fit: float = float(np.std(data, ddof=0))
+
+    # Log-likelihoods
+    ll_normal: float = float(np.sum(stats.norm.logpdf(data, loc=mu_fit, scale=sigma_fit)))
+    ll_student_t: float = float(np.sum(stats.t.logpdf(data, df=nu_fit, loc=loc_fit, scale=scale_fit)))
+
+    # AIC / BIC
+    aic_normal: float = _compute_aic(_N_PARAMS_NORMAL, ll_normal)
+    aic_student_t: float = _compute_aic(_N_PARAMS_STUDENT_T, ll_student_t)
+    bic_normal: float = _compute_bic(_N_PARAMS_NORMAL, n, ll_normal)
+    bic_student_t: float = _compute_bic(_N_PARAMS_STUDENT_T, n, ll_student_t)
+    best_fit: str = "student_t" if aic_student_t < aic_normal else "normal"
+
+    # KS statistic against fitted Normal
+    ks_result: tuple[float, float] = stats.kstest(data, "norm", args=(mu_fit, sigma_fit))  # type: ignore[no-untyped-call]
+    ks_statistic: float = float(ks_result[0])
+
+    return _FitResult(
+        student_t_nu=float(nu_fit),
+        student_t_loc=float(loc_fit),
+        student_t_scale=float(scale_fit),
+        aic_normal=aic_normal,
+        aic_student_t=aic_student_t,
+        bic_normal=bic_normal,
+        bic_student_t=bic_student_t,
+        best_fit=best_fit,
+        ks_statistic=ks_statistic,
+    )
+
+
+class DistributionAnalyzer:
+    """Stateless service for return distribution profiling.
+
+    Performs tier-gated analysis:
+
+    - **All tiers:** log return computation, descriptive stats, Jarque-Bera test.
+    - **Tier A / B:** Student-t MLE fitting, AIC/BIC comparison, KS distance.
+    - **Tier C:** descriptive stats only (Student-t fields set to ``None``).
+    """
+
+    def analyze(  # noqa: PLR6301
+        self,
+        returns: pd.Series,  # type: ignore[type-arg]
+        asset: str,
+        bar_type: str,
+        tier: SampleTier,
+        config: DistributionConfig | None = None,
+    ) -> DistributionProfile:
+        """Compute a full distribution profile for a return series.
+
+        Args:
+            returns: Pandas Series of log returns (NaN-free).
+            asset: Trading pair symbol (e.g. ``"BTCUSDT"``).
+            bar_type: Bar aggregation type (e.g. ``"dollar"``).
+            tier: Sample-size tier controlling analysis depth.
+            config: Distribution analysis configuration. Uses defaults
+                when ``None``.
+
+        Returns:
+            Frozen ``DistributionProfile`` value object.
+        """
+        if config is None:
+            config = DistributionConfig()
+
+        n: int = len(returns)
+        logger.debug(
+            "Analysing return distribution: asset={}, bar_type={}, tier={}, n={}",
+            asset,
+            bar_type,
+            tier.value,
+            n,
+        )
+
+        desc: _DescriptiveStats = _compute_descriptive_stats(returns, n)
+        jb: _JBResult = _compute_jb_test(returns, n, desc.std_return, config)
+
+        # Tier A / B: Student-t MLE, AIC/BIC, KS
+        fit: _FitResult | None = None
+        can_fit: bool = tier in {SampleTier.A, SampleTier.B} and n >= config.min_samples_fit and desc.std_return > 0
+        if can_fit:
+            data: np.ndarray[tuple[int], np.dtype[np.float64]] = returns.to_numpy(dtype=np.float64)
+            fit = _fit_distributions(data, n)
+            logger.debug(
+                "Fit results: nu={:.2f}, AIC(N)={:.1f}, AIC(t)={:.1f}, best={}, KS_Dn={:.4f}",
+                fit.student_t_nu,
+                fit.aic_normal,
+                fit.aic_student_t,
+                fit.best_fit,
+                fit.ks_statistic,
+            )
+
+        return DistributionProfile(
+            asset=asset,
+            bar_type=bar_type,
+            tier=tier,
+            n_observations=n,
+            mean_return=desc.mean_return,
+            std_return=desc.std_return,
+            skewness=desc.skewness,
+            excess_kurtosis=desc.excess_kurtosis,
+            jb_stat=jb.jb_stat,
+            jb_pvalue=jb.jb_pvalue,
+            is_normal=jb.is_normal,
+            student_t_nu=fit.student_t_nu if fit else None,
+            student_t_loc=fit.student_t_loc if fit else None,
+            student_t_scale=fit.student_t_scale if fit else None,
+            aic_normal=fit.aic_normal if fit else None,
+            aic_student_t=fit.aic_student_t if fit else None,
+            bic_normal=fit.bic_normal if fit else None,
+            bic_student_t=fit.bic_student_t if fit else None,
+            best_fit=fit.best_fit if fit else None,
+            ks_statistic=fit.ks_statistic if fit else None,
+        )
+
+    def compute_qq_data_student_t(  # noqa: PLR6301
+        self,
+        returns: pd.Series,  # type: ignore[type-arg]
+        nu: float,
+        loc: float,
+        scale: float,
+    ) -> tuple[np.ndarray[tuple[int], np.dtype[np.float64]], np.ndarray[tuple[int], np.dtype[np.float64]]]:
+        """Extract Q-Q plot data against a fitted Student-t distribution.
+
+        Computes theoretical quantiles from the fitted Student-t
+        distribution and pairs them with the ordered sample values.
+
+        Args:
+            returns: Series of return observations.
+            nu: Fitted degrees of freedom.
+            loc: Fitted location parameter.
+            scale: Fitted scale parameter.
+
+        Returns:
+            Tuple of ``(theoretical_quantiles, ordered_values)`` where both
+            arrays have the same length as ``returns``.
+        """
+        _min_qq_samples: int = 3
+        clean: pd.Series[float] = returns.dropna()  # type: ignore[type-arg]
+
+        if len(clean) < _min_qq_samples:
+            empty: np.ndarray[tuple[int], np.dtype[np.float64]] = np.array([], dtype=np.float64)
+            return empty, empty
+
+        n: int = len(clean)
+        ordered: np.ndarray[tuple[int], np.dtype[np.float64]] = np.sort(clean.to_numpy(dtype=np.float64))
+
+        # Compute theoretical quantiles using plotting positions
+        # Blom's approximation: (i - 3/8) / (n + 1/4)
+        positions: np.ndarray[tuple[int], np.dtype[np.float64]] = (np.arange(1, n + 1, dtype=np.float64) - 0.375) / (
+            n + 0.25
+        )
+        theoretical: np.ndarray[tuple[int], np.dtype[np.float64]] = np.asarray(
+            stats.t.ppf(positions, df=nu, loc=loc, scale=scale),  # type: ignore[no-untyped-call]
+            dtype=np.float64,
+        )
+
+        return theoretical, ordered

--- a/src/app/profiling/domain/value_objects.py
+++ b/src/app/profiling/domain/value_objects.py
@@ -1,4 +1,4 @@
-"""Profiling domain value objects -- data partitions, sample tiers, and stationarity results."""
+"""Profiling domain value objects -- data partitions, sample tiers, distribution profiles, and stationarity results."""
 
 from __future__ import annotations
 
@@ -217,6 +217,87 @@ class TierClassifier:
         if n_samples >= config.tier_b_threshold:
             return SampleTier.B
         return SampleTier.C
+
+
+class DistributionConfig(BaseModel, frozen=True):
+    """Configuration for return distribution analysis.
+
+    Attributes:
+        jb_alpha: Significance level for the Jarque-Bera normality test.
+        price_col: Name of the price column used to compute log returns.
+        min_samples_jb: Minimum number of samples required for Jarque-Bera test.
+        min_samples_fit: Minimum number of samples required for MLE fitting.
+    """
+
+    jb_alpha: Annotated[float, PydanticField(gt=0, lt=1)] = 0.05
+    price_col: str = "close"
+    min_samples_jb: Annotated[int, PydanticField(ge=3)] = 3
+    min_samples_fit: Annotated[int, PydanticField(ge=10)] = 30
+
+
+class DistributionProfile(BaseModel, frozen=True):
+    """Per-asset, per-bar-type return distribution profile.
+
+    Contains Jarque-Bera normality test results, effect sizes,
+    Student-t MLE fit parameters, AIC/BIC model comparison,
+    and KS distance measure. Tier-gated: Tier C gets descriptive
+    stats only (Student-t fields are None).
+
+    Attributes:
+        asset: Trading pair symbol (e.g. ``"BTCUSDT"``).
+        bar_type: Bar aggregation type (e.g. ``"dollar"``).
+        tier: Sample-size tier that controls analysis depth.
+        n_observations: Number of return observations analysed.
+        mean_return: Mean of log returns.
+        std_return: Standard deviation of log returns.
+        skewness: Fisher skewness of log returns.
+        excess_kurtosis: Fisher excess kurtosis of log returns.
+        jb_stat: Jarque-Bera test statistic.
+        jb_pvalue: Jarque-Bera p-value.
+        is_normal: Whether normality was NOT rejected at the configured alpha.
+        student_t_nu: Fitted Student-t degrees of freedom (Tier A/B only).
+        student_t_loc: Fitted Student-t location parameter (Tier A/B only).
+        student_t_scale: Fitted Student-t scale parameter (Tier A/B only).
+        aic_normal: AIC for the fitted Normal distribution (Tier A/B only).
+        aic_student_t: AIC for the fitted Student-t distribution (Tier A/B only).
+        bic_normal: BIC for the fitted Normal distribution (Tier A/B only).
+        bic_student_t: BIC for the fitted Student-t distribution (Tier A/B only).
+        best_fit: Best-fitting distribution by AIC (Tier A/B only).
+        ks_statistic: KS D_n statistic vs fitted Normal (Tier A/B only).
+    """
+
+    asset: str
+    bar_type: str
+    tier: SampleTier
+
+    # Sample info
+    n_observations: Annotated[int, PydanticField(ge=0)]
+
+    # Descriptive statistics (all tiers)
+    mean_return: float
+    std_return: Annotated[float, PydanticField(ge=0)]
+    skewness: float
+    excess_kurtosis: float
+
+    # Jarque-Bera normality test (all tiers)
+    jb_stat: Annotated[float, PydanticField(ge=0)]
+    jb_pvalue: Annotated[float, PydanticField(ge=0, le=1)]
+    is_normal: bool
+
+    # Student-t MLE fit (Tier A/B only -- None for Tier C)
+    student_t_nu: float | None = None
+    student_t_loc: float | None = None
+    student_t_scale: float | None = None
+
+    # Model comparison (Tier A/B only -- None for Tier C)
+    aic_normal: float | None = None
+    aic_student_t: float | None = None
+    bic_normal: float | None = None
+    bic_student_t: float | None = None
+    best_fit: str | None = None
+
+    # KS distance measure (Tier A/B only -- None for Tier C)
+    ks_statistic: float | None = None
 
 
 class StationarityTestResult(BaseModel, frozen=True):

--- a/src/tests/profiling/conftest.py
+++ b/src/tests/profiling/conftest.py
@@ -1,13 +1,14 @@
 """Shared fixtures and factory functions for profiling module tests.
 
-Provides synthetic data generators for stationarity testing and
-reusable configuration fixtures.
+Provides synthetic data generators for stationarity testing,
+distribution analysis, and reusable configuration fixtures.
 """
 
 from __future__ import annotations
 
 import numpy as np
 import pandas as pd  # type: ignore[import-untyped]
+from scipy import stats  # type: ignore[import-untyped]
 
 
 def make_stationary_series(
@@ -70,3 +71,79 @@ def make_stationarity_test_df(
     )
     feature_names: list[str] = ["stationary_feat", "unit_root_feat"]
     return df, feature_names
+
+
+# ---------------------------------------------------------------------------
+# Distribution analysis helpers
+# ---------------------------------------------------------------------------
+
+
+def make_normal_returns(
+    n: int = 5000,
+    seed: int = 42,
+) -> pd.Series:  # type: ignore[type-arg]
+    """Generate normally distributed returns with realistic crypto-scale volatility.
+
+    Draws from ``N(0, 0.01)`` (mean=0, std=1% per bar).
+
+    Args:
+        n: Number of return observations.
+        seed: Random seed for reproducibility.
+
+    Returns:
+        Pandas Series of i.i.d. Normal returns.
+    """
+    rng = np.random.default_rng(seed)
+    data = rng.normal(loc=0.0, scale=0.01, size=n)
+    return pd.Series(data, dtype=np.float64, name="log_return")
+
+
+def make_student_t_returns(
+    n: int = 5000,
+    nu: float = 5.0,
+    seed: int = 42,
+) -> pd.Series:  # type: ignore[type-arg]
+    """Generate Student-t distributed returns with given degrees of freedom.
+
+    Draws from ``t(nu)`` scaled to realistic return magnitude (scale=0.01).
+
+    Args:
+        n: Number of return observations.
+        nu: Degrees of freedom (lower = heavier tails).
+        seed: Random seed for reproducibility.
+
+    Returns:
+        Pandas Series of Student-t returns.
+    """
+    rng = np.random.default_rng(seed)
+    data = rng.standard_t(df=nu, size=n) * 0.01
+    return pd.Series(data, dtype=np.float64, name="log_return")
+
+
+def make_skewed_returns(
+    n: int = 5000,
+    skew_direction: str = "left",
+    seed: int = 42,
+) -> pd.Series:  # type: ignore[type-arg]
+    """Generate skewed returns for testing skewness detection.
+
+    Uses ``scipy.stats.skewnorm`` to produce left- or right-skewed samples.
+
+    Args:
+        n: Number of return observations.
+        skew_direction: ``"left"`` for negative skew, ``"right"`` for positive.
+        seed: Random seed for reproducibility.
+
+    Returns:
+        Pandas Series of skewed returns.
+
+    Raises:
+        ValueError: If *skew_direction* is not ``"left"`` or ``"right"``.
+    """
+    if skew_direction not in {"left", "right"}:
+        msg = f"skew_direction must be 'left' or 'right', got '{skew_direction}'"
+        raise ValueError(msg)
+
+    a = -5.0 if skew_direction == "left" else 5.0
+    data = stats.skewnorm.rvs(a, size=n, random_state=seed) * 0.01
+    return pd.Series(data, dtype=np.float64, name="log_return")

--- a/src/tests/profiling/test_distribution.py
+++ b/src/tests/profiling/test_distribution.py
@@ -1,0 +1,426 @@
+"""Tests for DistributionAnalyzer against synthetic return distributions.
+
+Verifies Jarque-Bera normality testing, Student-t MLE fitting,
+AIC/BIC model comparison, KS distance, and tier-gated behaviour.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd  # type: ignore[import-untyped]
+import pytest
+
+from src.app.profiling.application.distribution import DistributionAnalyzer
+from src.app.profiling.domain.value_objects import (
+    DistributionConfig,
+    SampleTier,
+)
+from src.tests.profiling.conftest import (
+    make_normal_returns,
+    make_skewed_returns,
+    make_student_t_returns,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _default_config() -> DistributionConfig:
+    """Return a default DistributionConfig for tests."""
+    return DistributionConfig()
+
+
+def _make_analyzer() -> DistributionAnalyzer:
+    """Return a fresh DistributionAnalyzer instance."""
+    return DistributionAnalyzer()
+
+
+# ---------------------------------------------------------------------------
+# Tier A — Normal data
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeNormalDataTierA:
+    """Tests for Tier A analysis on normally distributed data."""
+
+    def test_jb_does_not_reject_normality(self) -> None:
+        """N(0, 0.01) data should not be rejected as non-normal by JB test."""
+        returns = make_normal_returns(n=5000, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A, _default_config())
+
+        assert profile.jb_pvalue > 0.05
+        assert profile.is_normal is True
+
+    def test_student_t_nu_is_high_for_normal(self) -> None:
+        """Normal data should yield high Student-t nu (approaching Gaussian)."""
+        returns = make_normal_returns(n=5000, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A, _default_config())
+
+        assert profile.student_t_nu is not None
+        assert profile.student_t_nu > 20
+
+    def test_aic_bic_fields_populated(self) -> None:
+        """Tier A analysis should populate all AIC/BIC fields."""
+        returns = make_normal_returns(n=5000, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A, _default_config())
+
+        assert profile.aic_normal is not None
+        assert profile.aic_student_t is not None
+        assert profile.bic_normal is not None
+        assert profile.bic_student_t is not None
+        assert profile.best_fit is not None
+
+    def test_ks_statistic_is_small_for_normal(self) -> None:
+        """KS D_n against fitted Normal should be small for Normal data."""
+        returns = make_normal_returns(n=5000, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A, _default_config())
+
+        assert profile.ks_statistic is not None
+        assert profile.ks_statistic < 0.05
+
+
+# ---------------------------------------------------------------------------
+# Tier A — Fat-tailed data
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeFatTailedDataTierA:
+    """Tests for Tier A analysis on Student-t(5) distributed data."""
+
+    def test_jb_rejects_normality(self) -> None:
+        """Student-t(5) data should be rejected as non-normal by JB test."""
+        returns = make_student_t_returns(n=5000, nu=5.0, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A, _default_config())
+
+        assert profile.jb_pvalue < 0.05
+        assert profile.is_normal is False
+
+    def test_fitted_nu_near_true_value(self) -> None:
+        """Fitted Student-t nu should be near the true value of 5."""
+        returns = make_student_t_returns(n=5000, nu=5.0, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A, _default_config())
+
+        assert profile.student_t_nu is not None
+        assert 3.0 <= profile.student_t_nu <= 8.0
+
+    def test_aic_prefers_student_t(self) -> None:
+        """AIC should prefer Student-t over Normal for fat-tailed data."""
+        returns = make_student_t_returns(n=5000, nu=5.0, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A, _default_config())
+
+        assert profile.aic_student_t is not None
+        assert profile.aic_normal is not None
+        assert profile.aic_student_t < profile.aic_normal
+        assert profile.best_fit == "student_t"
+
+
+# ---------------------------------------------------------------------------
+# Tier C — descriptive stats only
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeTierC:
+    """Tests for Tier C analysis (descriptive stats only)."""
+
+    def test_descriptive_stats_populated(self) -> None:
+        """Tier C should still produce descriptive statistics."""
+        returns = make_normal_returns(n=100, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.C, _default_config())
+
+        assert profile.n_observations == 100
+        # mean_return may be near zero for normal data -- just check it's finite
+        assert math.isfinite(profile.mean_return)
+        assert profile.std_return > 0.0
+
+    def test_student_t_fields_are_none(self) -> None:
+        """Tier C should not populate Student-t fitting fields."""
+        returns = make_normal_returns(n=100, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.C, _default_config())
+
+        assert profile.student_t_nu is None
+        assert profile.student_t_loc is None
+        assert profile.student_t_scale is None
+
+    def test_aic_bic_are_none(self) -> None:
+        """Tier C should not populate AIC/BIC fields."""
+        returns = make_normal_returns(n=100, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.C, _default_config())
+
+        assert profile.aic_normal is None
+        assert profile.aic_student_t is None
+        assert profile.bic_normal is None
+        assert profile.bic_student_t is None
+        assert profile.best_fit is None
+
+    def test_ks_statistic_is_none(self) -> None:
+        """Tier C should not populate KS statistic."""
+        returns = make_normal_returns(n=100, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.C, _default_config())
+
+        assert profile.ks_statistic is None
+
+
+# ---------------------------------------------------------------------------
+# Tier B — same depth as Tier A
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeTierB:
+    """Tests for Tier B analysis (same fitting depth as Tier A)."""
+
+    def test_student_t_fields_populated(self) -> None:
+        """Tier B should fit Student-t distribution like Tier A."""
+        returns = make_normal_returns(n=1000, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.B, _default_config())
+
+        assert profile.student_t_nu is not None
+        assert profile.student_t_loc is not None
+        assert profile.student_t_scale is not None
+        assert profile.aic_normal is not None
+        assert profile.aic_student_t is not None
+        assert profile.ks_statistic is not None
+
+
+# ---------------------------------------------------------------------------
+# Skewness tests
+# ---------------------------------------------------------------------------
+
+
+class TestSkewness:
+    """Tests for skewness computation on known distributions."""
+
+    def test_symmetric_data_near_zero_skewness(self) -> None:
+        """Symmetric (Normal) data should have skewness near zero."""
+        returns = make_normal_returns(n=5000, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A, _default_config())
+
+        assert abs(profile.skewness) < 0.1
+
+    def test_left_skewed_data_negative_skewness(self) -> None:
+        """Left-skewed data should have negative skewness."""
+        returns = make_skewed_returns(n=5000, skew_direction="left", seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A, _default_config())
+
+        assert profile.skewness < 0.0
+
+
+# ---------------------------------------------------------------------------
+# Excess kurtosis tests
+# ---------------------------------------------------------------------------
+
+
+class TestExcessKurtosis:
+    """Tests for excess kurtosis computation."""
+
+    def test_normal_data_kurtosis_near_zero(self) -> None:
+        """Normal data should have excess kurtosis near 0."""
+        returns = make_normal_returns(n=5000, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A, _default_config())
+
+        assert abs(profile.excess_kurtosis) < 0.3
+
+    def test_fat_tailed_data_high_kurtosis(self) -> None:
+        """Student-t(3) data should have very high excess kurtosis."""
+        returns = make_student_t_returns(n=5000, nu=3.0, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A, _default_config())
+
+        # Student-t(3) theoretical excess kurtosis = infinity,
+        # but finite sample estimate should be large (> 3)
+        assert profile.excess_kurtosis > 3.0
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Tests for edge cases and graceful degradation."""
+
+    def test_constant_returns_graceful(self) -> None:
+        """Constant returns (std=0) should be handled gracefully."""
+        returns = pd.Series(np.zeros(100), dtype=np.float64, name="log_return")
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A, _default_config())
+
+        assert profile.std_return == 0.0
+        assert profile.jb_stat == 0.0
+        assert profile.jb_pvalue == 1.0
+        assert profile.is_normal is True
+        # Student-t fitting is skipped when std=0
+        assert profile.student_t_nu is None
+
+    def test_too_few_samples_for_jb(self) -> None:
+        """Fewer than min_samples_jb should skip JB test gracefully."""
+        returns = pd.Series([0.01, -0.02], dtype=np.float64, name="log_return")
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A, _default_config())
+
+        assert profile.jb_stat == 0.0
+        assert profile.jb_pvalue == 1.0
+
+    def test_too_few_samples_for_fit(self) -> None:
+        """Fewer than min_samples_fit should skip Student-t fitting."""
+        returns = make_normal_returns(n=20, seed=42)
+        config = DistributionConfig(min_samples_fit=30)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A, config)
+
+        assert profile.student_t_nu is None
+        assert profile.aic_normal is None
+
+
+# ---------------------------------------------------------------------------
+# QQ data against Student-t
+# ---------------------------------------------------------------------------
+
+
+class TestQQDataStudentT:
+    """Tests for compute_qq_data_student_t."""
+
+    def test_returns_two_equal_length_arrays(self) -> None:
+        """QQ data should return two arrays of equal length."""
+        returns = make_student_t_returns(n=500, nu=5.0, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A, _default_config())
+
+        assert profile.student_t_nu is not None
+        theoretical, ordered = _make_analyzer().compute_qq_data_student_t(
+            returns, profile.student_t_nu, profile.student_t_loc or 0.0, profile.student_t_scale or 1.0
+        )
+
+        assert len(theoretical) == len(ordered)
+        assert len(theoretical) == len(returns)
+
+    def test_good_fit_points_near_diagonal(self) -> None:
+        """For Student-t data with correct params, QQ points should be near the diagonal."""
+        returns = make_student_t_returns(n=5000, nu=5.0, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A, _default_config())
+
+        assert profile.student_t_nu is not None
+        theoretical, ordered = _make_analyzer().compute_qq_data_student_t(
+            returns, profile.student_t_nu, profile.student_t_loc or 0.0, profile.student_t_scale or 1.0
+        )
+
+        # Compute correlation between theoretical and ordered quantiles
+        # A good fit should give R > 0.99
+        correlation = np.corrcoef(theoretical, ordered)[0, 1]
+        assert correlation > 0.99
+
+    def test_too_few_samples_returns_empty(self) -> None:
+        """Fewer than 3 samples should return empty arrays."""
+        returns = pd.Series([0.01, -0.01], dtype=np.float64, name="log_return")
+        theoretical, ordered = _make_analyzer().compute_qq_data_student_t(returns, 5.0, 0.0, 0.01)
+
+        assert len(theoretical) == 0
+        assert len(ordered) == 0
+
+
+# ---------------------------------------------------------------------------
+# KS statistic range
+# ---------------------------------------------------------------------------
+
+
+class TestKSStatistic:
+    """Tests for KS D_n statistic validity."""
+
+    def test_ks_in_zero_one_range(self) -> None:
+        """KS D_n statistic should always be in [0, 1]."""
+        returns = make_student_t_returns(n=5000, nu=5.0, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A, _default_config())
+
+        assert profile.ks_statistic is not None
+        assert 0.0 <= profile.ks_statistic <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# AIC / BIC consistency
+# ---------------------------------------------------------------------------
+
+
+class TestAICBICConsistency:
+    """Tests for AIC / BIC model selection consistency."""
+
+    def test_both_prefer_student_t_for_fat_tails(self) -> None:
+        """Both AIC and BIC should prefer Student-t for fat-tailed data."""
+        returns = make_student_t_returns(n=5000, nu=5.0, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A, _default_config())
+
+        assert profile.aic_student_t is not None
+        assert profile.aic_normal is not None
+        assert profile.bic_student_t is not None
+        assert profile.bic_normal is not None
+
+        assert profile.aic_student_t < profile.aic_normal
+        assert profile.bic_student_t < profile.bic_normal
+
+
+# ---------------------------------------------------------------------------
+# Deterministic output
+# ---------------------------------------------------------------------------
+
+
+class TestDeterministicOutput:
+    """Tests for reproducibility of analysis results."""
+
+    def test_same_input_same_output(self) -> None:
+        """Identical input should produce identical output."""
+        returns = make_student_t_returns(n=1000, nu=5.0, seed=123)
+        config = _default_config()
+        analyzer = _make_analyzer()
+
+        profile_1 = analyzer.analyze(returns, "BTCUSDT", "dollar", SampleTier.A, config)
+        profile_2 = analyzer.analyze(returns, "BTCUSDT", "dollar", SampleTier.A, config)
+
+        assert profile_1 == profile_2
+
+
+# ---------------------------------------------------------------------------
+# Value object construction
+# ---------------------------------------------------------------------------
+
+
+class TestDistributionProfile:
+    """Tests for DistributionProfile value object construction."""
+
+    def test_frozen_immutability(self) -> None:
+        """DistributionProfile should be immutable."""
+        from pydantic import ValidationError
+
+        returns = make_normal_returns(n=100, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.C, _default_config())
+
+        with pytest.raises(ValidationError):
+            profile.mean_return = 999.0  # type: ignore[misc]
+
+    def test_metadata_fields(self) -> None:
+        """Profile should carry correct asset, bar_type, and tier metadata."""
+        returns = make_normal_returns(n=100, seed=42)
+        profile = _make_analyzer().analyze(returns, "ETHUSDT", "volume", SampleTier.C, _default_config())
+
+        assert profile.asset == "ETHUSDT"
+        assert profile.bar_type == "volume"
+        assert profile.tier == SampleTier.C
+        assert profile.n_observations == 100
+
+
+class TestDistributionConfig:
+    """Tests for DistributionConfig value object construction."""
+
+    def test_default_values(self) -> None:
+        """Default config should have sensible defaults."""
+        config = DistributionConfig()
+
+        assert config.jb_alpha == 0.05
+        assert config.price_col == "close"
+        assert config.min_samples_jb == 3
+        assert config.min_samples_fit == 30
+
+    def test_frozen_immutability(self) -> None:
+        """DistributionConfig should be immutable."""
+        from pydantic import ValidationError
+
+        config = DistributionConfig()
+
+        with pytest.raises(ValidationError):
+            config.jb_alpha = 0.1  # type: ignore[misc]


### PR DESCRIPTION
## Summary

- Add `DistributionProfile` and `DistributionConfig` value objects to `profiling/domain/value_objects.py` with tier-gated fields (Student-t MLE fit, AIC/BIC, KS statistic are Tier A/B only; Tier C gets descriptive stats only)
- Add `DistributionAnalyzer` service in `profiling/application/distribution.py` performing Jarque-Bera normality testing, Student-t MLE fitting via `scipy.stats.t.fit()`, AIC/BIC model comparison (Normal vs Student-t), KS D_n distance measure, and QQ data computation against fitted Student-t
- Add 29 tests covering normal data, fat-tailed data, tier-gated behaviour (A/B/C), skewness, excess kurtosis, edge cases (constant returns, too few samples), QQ data, KS range, AIC/BIC consistency, deterministic output, and value object immutability

## Implementation Details

- **Tier gating**: Tier A/B get full analysis (descriptive stats + JB + Student-t MLE + AIC/BIC + KS). Tier C gets descriptive stats and JB only.
- **Edge cases**: Constant returns (std=0) gracefully skip fitting. Insufficient samples skip JB or fitting as configured.
- **AIC/BIC**: `AIC = 2k - 2*LL`, `BIC = k*ln(n) - 2*LL`. `best_fit` selected by AIC.
- **KS statistic**: Tests against *fitted* Normal (not standard Normal). Reports D_n only (not p-value, which is anti-conservative for fitted parameters).
- Internal containers use `NamedTuple` to keep the analyzer method within ruff's statement/variable limits.

## Test plan

- [x] `just test src/tests/profiling/` -- 73 tests pass (29 new + 44 existing)
- [x] `just test` -- all 746 tests pass
- [x] `just lint` -- ruff format, ruff check, pyright all clean
- [x] Pre-commit hooks pass on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)