### PR TITLE
feat(profiling): add Phase 5B autocorrelation & serial dependence analysis

### DIFF
--- a/src/app/profiling/application/serial_dependence.py
+++ b/src/app/profiling/application/serial_dependence.py
@@ -1,0 +1,450 @@
+"""Autocorrelation, variance ratio, and Granger causality analysis.
+
+Implements tier-gated serial dependence profiling using the ML-research
+path (Pandas / NumPy / statsmodels / arch) per CLAUDE.md.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pandas as pd  # type: ignore[import-untyped]
+from arch.unitroot import VarianceRatio  # type: ignore[import-untyped]
+from loguru import logger
+from scipy.stats import norm  # type: ignore[import-untyped]
+from statsmodels.stats.diagnostic import acorr_ljungbox  # type: ignore[import-untyped]
+from statsmodels.tsa.stattools import acf, grangercausalitytests, pacf  # type: ignore[import-untyped]
+
+from src.app.profiling.domain.value_objects import (
+    AutocorrelationConfig,
+    AutocorrelationProfile,
+    GrangerResult,
+    LjungBoxResult,
+    SampleTier,
+    VarianceRatioResult,
+)
+
+# ---------------------------------------------------------------------------
+# Minimum observation thresholds
+# ---------------------------------------------------------------------------
+
+_MIN_ACF_SAMPLES: int = 4
+"""Minimum samples required for meaningful ACF/PACF computation."""
+
+_TIER_B_MAX_VR_HORIZON_DAYS: float = 7.0
+"""Maximum variance ratio calendar horizon (days) allowed for Tier B."""
+
+
+class SerialDependenceAnalyzer:
+    """Stateless service for autocorrelation, variance ratio, and Granger causality analysis.
+
+    Tier-gated:
+        - **All tiers:** ACF/PACF, multi-lag Ljung-Box.
+        - **Tier A/B:** Lo-MacKinlay variance ratio (robust Z2), Chow-Denning.
+        - **Tier A only:** Granger causality.
+        - **Tier B:** VR capped at 1-week horizon.
+        - **Tier C:** ACF/PACF + Ljung-Box only.
+    """
+
+    def analyze(  # noqa: PLR6301, PLR0913, PLR0917
+        self,
+        returns: pd.Series,  # type: ignore[type-arg]
+        asset: str,
+        bar_type: str,
+        tier: SampleTier,
+        bars_per_day: float,
+        config: AutocorrelationConfig | None = None,
+        squared_returns: pd.Series | None = None,  # type: ignore[type-arg]
+    ) -> AutocorrelationProfile:
+        """Compute a full autocorrelation and serial dependence profile.
+
+        Args:
+            returns: Pandas Series of log returns (NaN-free).
+            asset: Trading pair symbol (e.g. ``"BTCUSDT"``).
+            bar_type: Bar aggregation type (e.g. ``"dollar"``).
+            tier: Sample-size tier controlling analysis depth.
+            bars_per_day: Average number of bars per calendar day, used
+                to convert variance ratio calendar horizons to bar counts.
+            config: Autocorrelation analysis configuration.  Uses defaults
+                when ``None``.
+            squared_returns: Pre-computed squared returns.  If ``None``,
+                computed as ``returns ** 2``.
+
+        Returns:
+            Frozen ``AutocorrelationProfile`` value object.
+        """
+        if config is None:
+            config = AutocorrelationConfig()
+
+        n_obs: int = len(returns)
+        logger.debug(
+            "Analysing serial dependence: asset={}, bar_type={}, tier={}, n={}",
+            asset,
+            bar_type,
+            tier.value,
+            n_obs,
+        )
+
+        # Compute squared returns if not provided
+        sq_returns: pd.Series = squared_returns if squared_returns is not None else returns**2  # type: ignore[type-arg]
+
+        # ACF / PACF for raw and squared returns (all tiers)
+        acf_vals: np.ndarray  # type: ignore[type-arg]
+        pacf_vals: np.ndarray  # type: ignore[type-arg]
+        acf_vals, pacf_vals = _compute_acf_pacf(returns, config.max_lag)
+
+        acf_sq_vals: np.ndarray  # type: ignore[type-arg]
+        pacf_sq_vals: np.ndarray  # type: ignore[type-arg]
+        acf_sq_vals, pacf_sq_vals = _compute_acf_pacf(sq_returns, config.max_lag)
+
+        # Ljung-Box tests (all tiers)
+        lb_returns: tuple[LjungBoxResult, ...] = _compute_ljung_box(returns, config.ljung_box_lags, config.alpha)
+        lb_squared: tuple[LjungBoxResult, ...] = _compute_ljung_box(sq_returns, config.ljung_box_lags, config.alpha)
+
+        has_serial: bool = any(r.significant for r in lb_returns)
+        has_vol_clustering: bool = any(r.significant for r in lb_squared)
+
+        # Variance ratio (Tier A / B)
+        vr_results: tuple[VarianceRatioResult, ...] | None = None
+        cd_stat: float | None = None
+        cd_pvalue: float | None = None
+
+        if tier in {SampleTier.A, SampleTier.B}:
+            vr_results, cd_stat, cd_pvalue = _compute_variance_ratios(
+                returns=returns,
+                bars_per_day=bars_per_day,
+                calendar_horizons=config.vr_calendar_horizons_days,
+                tier=tier,
+                robust=config.vr_robust,
+                alpha=config.alpha,
+            )
+
+        # Granger causality (Tier A only) -- handled externally via test_granger_pairs
+        granger_results: tuple[GrangerResult, ...] | None = None
+
+        return AutocorrelationProfile(
+            asset=asset,
+            bar_type=bar_type,
+            tier=tier,
+            n_observations=n_obs,
+            acf_values=acf_vals,
+            pacf_values=pacf_vals,
+            acf_squared_values=acf_sq_vals,
+            pacf_squared_values=pacf_sq_vals,
+            ljung_box_returns=lb_returns,
+            ljung_box_squared=lb_squared,
+            has_serial_correlation=has_serial,
+            has_volatility_clustering=has_vol_clustering,
+            vr_results=vr_results,
+            chow_denning_stat=cd_stat,
+            chow_denning_pvalue=cd_pvalue,
+            granger_results=granger_results,
+        )
+
+    def test_granger_pairs(  # noqa: PLR6301
+        self,
+        returns_dict: dict[str, pd.Series],  # type: ignore[type-arg]
+        lags: tuple[int, ...],
+        alpha: float,
+    ) -> tuple[GrangerResult, ...]:
+        """Test Granger causality across all ordered pairs from a returns dictionary.
+
+        For a dictionary with keys {A, B, C}, tests all ordered pairs:
+        A->B, A->C, B->A, B->C, C->A, C->B.
+
+        Args:
+            returns_dict: Mapping from series label to return series.
+            lags: Lag values to test for each pair.
+            alpha: Significance level for the F-test.
+
+        Returns:
+            Tuple of all ``GrangerResult`` objects across all pairs and lags.
+        """
+        all_results: list[GrangerResult] = []
+        names: list[str] = list(returns_dict.keys())
+
+        for i, source_name in enumerate(names):
+            for j, target_name in enumerate(names):
+                if i == j:
+                    continue
+                source: pd.Series = returns_dict[source_name]  # type: ignore[type-arg]
+                target: pd.Series = returns_dict[target_name]  # type: ignore[type-arg]
+                pair_results: tuple[GrangerResult, ...] = _compute_granger(
+                    source=source,
+                    target=target,
+                    source_name=source_name,
+                    target_name=target_name,
+                    lags=lags,
+                    alpha=alpha,
+                )
+                all_results.extend(pair_results)
+
+        return tuple(all_results)
+
+
+# ---------------------------------------------------------------------------
+# Internal computation functions
+# ---------------------------------------------------------------------------
+
+
+def _compute_acf_pacf(
+    series: pd.Series,  # type: ignore[type-arg]
+    max_lag: int,
+) -> tuple[np.ndarray, np.ndarray]:  # type: ignore[type-arg]
+    """Compute ACF and PACF arrays for a series.
+
+    Caps ``max_lag`` at ``n_obs // 2 - 1`` to satisfy PACF requirements.
+    Returns empty arrays when the series is too short.
+
+    Args:
+        series: Pandas Series of observations.
+        max_lag: Requested maximum lag order.
+
+    Returns:
+        Tuple of ``(acf_array, pacf_array)``.
+    """
+    n_obs: int = len(series)
+    pacf_limit: int = n_obs // 2 - 1
+    effective_lag: int = min(max_lag, pacf_limit)
+
+    empty: np.ndarray = np.array([], dtype=np.float64)  # type: ignore[type-arg]
+    if n_obs < _MIN_ACF_SAMPLES or effective_lag < 1:
+        return empty, empty
+
+    data: np.ndarray = series.to_numpy(dtype=np.float64)  # type: ignore[type-arg]
+
+    # acf returns (values, confint) when alpha is specified; we only need values
+    acf_result: tuple[np.ndarray, np.ndarray] = acf(data, nlags=effective_lag, alpha=0.05)  # type: ignore[type-arg, assignment]
+    acf_values: np.ndarray = acf_result[0]  # type: ignore[type-arg]
+
+    pacf_values: np.ndarray = pacf(data, nlags=effective_lag, method="ywm")  # type: ignore[type-arg]
+
+    return acf_values, pacf_values
+
+
+def _compute_ljung_box(
+    series: pd.Series,  # type: ignore[type-arg]
+    lags: tuple[int, ...],
+    alpha: float,
+) -> tuple[LjungBoxResult, ...]:
+    """Run Ljung-Box test at multiple lag values.
+
+    Filters out lags that are >= ``n_obs // 2`` to avoid degenerate results.
+    Replaces NaN statistics with 0.0 and NaN p-values with 1.0.
+
+    Args:
+        series: Pandas Series of observations.
+        lags: Requested lag values.
+        alpha: Significance level.
+
+    Returns:
+        Tuple of ``LjungBoxResult``, one per valid lag.
+    """
+    n_obs: int = len(series)
+    max_valid_lag: int = n_obs // 2 - 1
+    valid_lags: list[int] = [lag for lag in lags if lag <= max_valid_lag and lag >= 1]
+
+    if not valid_lags:
+        return ()
+
+    lb_df: pd.DataFrame = acorr_ljungbox(series, lags=valid_lags)  # type: ignore[arg-type]
+
+    results: list[LjungBoxResult] = []
+    for lag_val in valid_lags:
+        q_stat: float = float(lb_df.loc[lag_val, "lb_stat"])
+        p_val: float = float(lb_df.loc[lag_val, "lb_pvalue"])
+
+        # Sanitise NaN values
+        if np.isnan(q_stat):
+            q_stat = 0.0
+        if np.isnan(p_val):
+            p_val = 1.0
+
+        significant: bool = p_val < alpha
+        results.append(
+            LjungBoxResult(
+                lag=lag_val,
+                q_statistic=q_stat,
+                p_value=p_val,
+                significant=significant,
+            )
+        )
+
+    return tuple(results)
+
+
+def _compute_variance_ratios(  # noqa: PLR0913, PLR0914, PLR0917
+    returns: pd.Series,  # type: ignore[type-arg]
+    bars_per_day: float,
+    calendar_horizons: tuple[float, ...],
+    tier: SampleTier,
+    robust: bool,
+    alpha: float,
+) -> tuple[tuple[VarianceRatioResult, ...], float | None, float | None]:
+    """Compute Lo-MacKinlay variance ratios and Chow-Denning joint test.
+
+    Converts calendar-day horizons to bar counts using ``bars_per_day``.
+    For Tier B, horizons exceeding 7 days are excluded.  Deduplicates
+    ``q`` values that collapse when ``bars_per_day`` is low.
+
+    The Chow-Denning statistic is ``max(|z_i|)`` across all tested horizons,
+    with p-value computed via Sidak correction.
+
+    Args:
+        returns: Pandas Series of log returns.
+        bars_per_day: Average bars per calendar day.
+        calendar_horizons: Calendar-day horizons to test.
+        tier: Sample-size tier (Tier B caps at 7-day horizon).
+        robust: Whether to use heteroscedasticity-robust Z2 statistic.
+        alpha: Significance level.
+
+    Returns:
+        Tuple of ``(vr_results, chow_denning_stat, chow_denning_pvalue)``.
+    """
+    returns_arr: np.ndarray = returns.to_numpy(dtype=np.float64)  # type: ignore[type-arg]
+    # arch.unitroot.VarianceRatio expects *price levels* (cumulative sum),
+    # not returns.  It internally differences to compute the variance ratio.
+    prices: np.ndarray = np.cumsum(returns_arr)  # type: ignore[type-arg]
+
+    # Filter horizons for Tier B
+    effective_horizons: list[float]
+    if tier == SampleTier.B:
+        effective_horizons = [h for h in calendar_horizons if h <= _TIER_B_MAX_VR_HORIZON_DAYS]
+    else:
+        effective_horizons = list(calendar_horizons)
+
+    # Convert calendar horizons to bar counts, deduplicate
+    seen_q: set[int] = set()
+    horizon_q_pairs: list[tuple[float, int]] = []
+    for horizon in effective_horizons:
+        q: int = max(2, round(horizon * bars_per_day))
+        if q not in seen_q:
+            seen_q.add(q)
+            horizon_q_pairs.append((horizon, q))
+
+    if not horizon_q_pairs:
+        return (), None, None
+
+    vr_results: list[VarianceRatioResult] = []
+    z_abs_values: list[float] = []
+
+    for cal_horizon, q_val in horizon_q_pairs:
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                vr_obj: VarianceRatio = VarianceRatio(prices, lags=q_val, robust=robust)  # type: ignore[no-untyped-call]
+
+            vr_value: float = float(vr_obj.vr)
+            z_stat: float = float(vr_obj.stat)
+            p_val: float = float(vr_obj.pvalue)
+
+            # Clamp p-value to [0, 1]
+            p_val = max(0.0, min(1.0, p_val))
+
+            significant: bool = p_val < alpha
+            z_abs_values.append(abs(z_stat))
+
+            vr_results.append(
+                VarianceRatioResult(
+                    calendar_horizon_days=cal_horizon,
+                    bar_count_q=q_val,
+                    variance_ratio=vr_value,
+                    z_statistic=z_stat,
+                    p_value=p_val,
+                    significant=significant,
+                )
+            )
+        except Exception:
+            logger.warning(
+                "Variance ratio failed for q={} (horizon={:.1f}d), skipping",
+                q_val,
+                cal_horizon,
+            )
+
+    if not vr_results:
+        return (), None, None
+
+    # Chow-Denning joint test: max(|z_i|) with Sidak correction
+    cd_stat: float = max(z_abs_values)
+    n_tests: int = len(z_abs_values)
+    # Sidak: P(reject at least one) = 1 - (1 - p_individual)^n
+    # where p_individual = 2 * (1 - Phi(|z_max|)) for two-sided test
+    p_individual: float = 2.0 * (1.0 - float(norm.cdf(cd_stat)))
+    cd_pvalue: float = 1.0 - (1.0 - p_individual) ** n_tests
+    cd_pvalue = max(0.0, min(1.0, cd_pvalue))
+
+    return tuple(vr_results), cd_stat, cd_pvalue
+
+
+def _compute_granger(  # noqa: PLR0913, PLR0917
+    source: pd.Series,  # type: ignore[type-arg]
+    target: pd.Series,  # type: ignore[type-arg]
+    source_name: str,
+    target_name: str,
+    lags: tuple[int, ...],
+    alpha: float,
+) -> tuple[GrangerResult, ...]:
+    """Run Granger causality tests for a single (source, target) pair at multiple lags.
+
+    Uses the SSR F-test from ``statsmodels.tsa.stattools.grangercausalitytests``.
+
+    Args:
+        source: Source (potential cause) return series.
+        target: Target (potential effect) return series.
+        source_name: Label for the source series.
+        target_name: Label for the target series.
+        lags: Lag values to test.
+        alpha: Significance level.
+
+    Returns:
+        Tuple of ``GrangerResult``, one per requested lag.
+    """
+    if len(source) != len(target):
+        logger.warning(
+            "Granger test: source ({}) and target ({}) have different lengths, skipping",
+            len(source),
+            len(target),
+        )
+        return ()
+
+    max_lag: int = max(lags)
+    # grangercausalitytests needs columns [target, source]
+    df: pd.DataFrame = pd.DataFrame(
+        {target_name: target.values, source_name: source.values},
+    )
+
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            gc_result: dict = grangercausalitytests(df, maxlag=max_lag, verbose=False)  # type: ignore[type-arg, no-untyped-call]
+    except Exception:
+        logger.warning(
+            "Granger causality test failed for {} -> {}, skipping",
+            source_name,
+            target_name,
+        )
+        return ()
+
+    results: list[GrangerResult] = []
+    for lag_val in lags:
+        if lag_val not in gc_result:
+            continue
+        ssr_ftest: tuple[float, float, float, int] = gc_result[lag_val][0]["ssr_ftest"]  # type: ignore[index]
+        f_stat: float = float(ssr_ftest[0])
+        p_val: float = float(ssr_ftest[1])
+        p_val = max(0.0, min(1.0, p_val))
+        significant: bool = p_val < alpha
+
+        results.append(
+            GrangerResult(
+                source_name=source_name,
+                target_name=target_name,
+                lag=lag_val,
+                f_statistic=f_stat,
+                p_value=p_val,
+                significant=significant,
+            )
+        )
+
+    return tuple(results)

--- a/src/app/profiling/domain/value_objects.py
+++ b/src/app/profiling/domain/value_objects.py
@@ -6,8 +6,9 @@ from datetime import datetime, UTC
 from enum import Enum
 from typing import Annotated, Self
 
+import numpy as np
 import polars as pl
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from pydantic import Field as PydanticField
 from pydantic import model_validator
 
@@ -348,3 +349,145 @@ class StationarityReport(BaseModel, frozen=True):
     n_non_stationary: int
     asset: str
     bar_type: str
+
+
+# ---------------------------------------------------------------------------
+# Phase 5B: Autocorrelation & serial dependence value objects
+# ---------------------------------------------------------------------------
+
+
+class AutocorrelationConfig(BaseModel, frozen=True):
+    """Configuration for autocorrelation and serial dependence analysis.
+
+    Attributes:
+        max_lag: Maximum lag order for ACF/PACF computation.
+        ljung_box_lags: Lag values at which to run Ljung-Box tests.
+        alpha: Significance level for hypothesis tests.
+        granger_max_lags: Lag values for Granger causality testing.
+        vr_calendar_horizons_days: Variance ratio horizons in calendar days,
+            converted to bar-count by the analyzer using ``bars_per_day``.
+        vr_robust: Whether to use heteroscedasticity-robust Z2 statistic
+            for the Lo-MacKinlay variance ratio test.
+    """
+
+    max_lag: Annotated[int, PydanticField(ge=1)] = 40
+    ljung_box_lags: tuple[int, ...] = (5, 10, 20, 40)
+    alpha: Annotated[float, PydanticField(gt=0, lt=1)] = 0.05
+    granger_max_lags: tuple[int, ...] = (1, 2, 4, 8)
+    vr_calendar_horizons_days: tuple[float, ...] = (1.0, 3.0, 7.0, 14.0)
+    vr_robust: bool = True
+
+
+class LjungBoxResult(BaseModel, frozen=True):
+    """Ljung-Box test result at a specific lag.
+
+    Attributes:
+        lag: Number of lags tested.
+        q_statistic: Ljung-Box Q statistic.
+        p_value: P-value of the test.
+        significant: Whether the test is significant at the configured alpha.
+    """
+
+    lag: Annotated[int, PydanticField(ge=1)]
+    q_statistic: Annotated[float, PydanticField(ge=0)]
+    p_value: Annotated[float, PydanticField(ge=0, le=1)]
+    significant: bool
+
+
+class VarianceRatioResult(BaseModel, frozen=True):
+    """Lo-MacKinlay variance ratio test result at a specific horizon.
+
+    Attributes:
+        calendar_horizon_days: The calendar horizon (in days) that was tested.
+        bar_count_q: The bar-count aggregation period derived from the horizon.
+        variance_ratio: Estimated variance ratio (VR = 1 under random walk null).
+        z_statistic: Z2 (robust) or Z1 test statistic.
+        p_value: Two-sided p-value of the z-statistic.
+        significant: Whether the test is significant at the configured alpha.
+    """
+
+    calendar_horizon_days: float
+    bar_count_q: Annotated[int, PydanticField(ge=2)]
+    variance_ratio: float
+    z_statistic: float
+    p_value: Annotated[float, PydanticField(ge=0, le=1)]
+    significant: bool
+
+
+class GrangerResult(BaseModel, frozen=True):
+    """Granger causality test result for a single (source, target, lag) pair.
+
+    Attributes:
+        source_name: Label of the source (cause) series.
+        target_name: Label of the target (effect) series.
+        lag: Number of lagged periods tested.
+        f_statistic: F-statistic from the SSR F-test.
+        p_value: P-value of the F-test.
+        significant: Whether the test is significant at the configured alpha.
+    """
+
+    source_name: str
+    target_name: str
+    lag: Annotated[int, PydanticField(ge=1)]
+    f_statistic: float
+    p_value: Annotated[float, PydanticField(ge=0, le=1)]
+    significant: bool
+
+
+class AutocorrelationProfile(BaseModel, frozen=True):
+    """Per-asset, per-bar-type autocorrelation and serial dependence profile.
+
+    Contains ACF/PACF arrays for raw and squared returns, multi-lag
+    Ljung-Box tests, Lo-MacKinlay variance ratios with Chow-Denning
+    joint test, and Granger causality results.  Fields are tier-gated:
+
+    - **All tiers:** ACF/PACF, multi-lag Ljung-Box.
+    - **Tier A/B:** Variance ratio (Tier B capped at 1-week horizon).
+    - **Tier A only:** Granger causality.
+    - **Tier C:** ACF/PACF + Ljung-Box only.
+
+    Attributes:
+        asset: Trading pair symbol (e.g. ``"BTCUSDT"``).
+        bar_type: Bar aggregation type (e.g. ``"dollar"``).
+        tier: Sample-size tier controlling analysis depth.
+        n_observations: Number of return observations analysed.
+        acf_values: ACF of raw returns (lag 0 included).
+        pacf_values: PACF of raw returns (lag 0 included).
+        acf_squared_values: ACF of squared returns.
+        pacf_squared_values: PACF of squared returns.
+        ljung_box_returns: Ljung-Box results on raw returns at multiple lags.
+        ljung_box_squared: Ljung-Box results on squared returns at multiple lags.
+        has_serial_correlation: Any Ljung-Box on returns is significant.
+        has_volatility_clustering: Any Ljung-Box on squared returns is significant.
+        vr_results: Variance ratio results per horizon (Tier A/B only).
+        chow_denning_stat: Chow-Denning joint test statistic (Tier A/B only).
+        chow_denning_pvalue: Chow-Denning p-value via Sidak correction (Tier A/B only).
+        granger_results: Granger causality results (Tier A only).
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    asset: str
+    bar_type: str
+    tier: SampleTier
+    n_observations: Annotated[int, PydanticField(ge=0)]
+
+    # ACF / PACF (all tiers)
+    acf_values: np.ndarray  # type: ignore[type-arg]
+    pacf_values: np.ndarray  # type: ignore[type-arg]
+    acf_squared_values: np.ndarray  # type: ignore[type-arg]
+    pacf_squared_values: np.ndarray  # type: ignore[type-arg]
+
+    # Ljung-Box at multiple lags (all tiers)
+    ljung_box_returns: tuple[LjungBoxResult, ...]
+    ljung_box_squared: tuple[LjungBoxResult, ...]
+    has_serial_correlation: bool
+    has_volatility_clustering: bool
+
+    # Variance ratio (Tier A/B -- None for Tier C)
+    vr_results: tuple[VarianceRatioResult, ...] | None = None
+    chow_denning_stat: float | None = None
+    chow_denning_pvalue: float | None = None
+
+    # Granger causality (Tier A only -- None for Tier B/C)
+    granger_results: tuple[GrangerResult, ...] | None = None

--- a/src/tests/profiling/conftest.py
+++ b/src/tests/profiling/conftest.py
@@ -1,7 +1,8 @@
 """Shared fixtures and factory functions for profiling module tests.
 
 Provides synthetic data generators for stationarity testing,
-distribution analysis, and reusable configuration fixtures.
+distribution analysis, serial dependence analysis, and reusable
+configuration fixtures.
 """
 
 from __future__ import annotations
@@ -147,3 +148,112 @@ def make_skewed_returns(
     a = -5.0 if skew_direction == "left" else 5.0
     data = stats.skewnorm.rvs(a, size=n, random_state=seed) * 0.01
     return pd.Series(data, dtype=np.float64, name="log_return")
+
+
+# ---------------------------------------------------------------------------
+# Serial dependence analysis helpers
+# ---------------------------------------------------------------------------
+
+
+def make_ar1_returns(
+    n: int = 1000,
+    phi: float = 0.5,
+    seed: int = 42,
+) -> pd.Series:  # type: ignore[type-arg]
+    """Generate an AR(1) return series with parameter *phi*.
+
+    ``r_t = phi * r_{t-1} + epsilon_t`` where ``epsilon ~ N(0, 0.01)``.
+
+    Args:
+        n: Number of return observations.
+        phi: AR(1) coefficient (|phi| < 1 for stationarity).
+        seed: Random seed for reproducibility.
+
+    Returns:
+        Pandas Series of AR(1) returns.
+    """
+    rng = np.random.default_rng(seed)
+    noise = rng.normal(loc=0.0, scale=0.01, size=n)
+    data = np.zeros(n, dtype=np.float64)
+    for i in range(1, n):
+        data[i] = phi * data[i - 1] + noise[i]
+    return pd.Series(data, dtype=np.float64, name="ar1_return")
+
+
+def make_random_walk_returns(
+    n: int = 1000,
+    seed: int = 42,
+) -> pd.Series:  # type: ignore[type-arg]
+    """Generate random walk returns (first differences of a random walk).
+
+    The *returns* are i.i.d. white noise ``N(0, 0.01)`` (since diff of
+    random walk = innovations).
+
+    Args:
+        n: Number of return observations.
+        seed: Random seed for reproducibility.
+
+    Returns:
+        Pandas Series of i.i.d. Normal returns.
+    """
+    rng = np.random.default_rng(seed)
+    data = rng.normal(loc=0.0, scale=0.01, size=n)
+    return pd.Series(data, dtype=np.float64, name="rw_return")
+
+
+def make_garch_like_returns(
+    n: int = 1000,
+    seed: int = 42,
+) -> pd.Series:  # type: ignore[type-arg]
+    """Generate returns with GARCH-like volatility clustering.
+
+    Uses a simple approximation: multiply white noise by a rolling
+    absolute return to create conditional heteroscedasticity.
+    ``sigma_t = 0.005 + 0.8 * |r_{t-1}|``, ``r_t = sigma_t * z_t``.
+
+    Args:
+        n: Number of return observations.
+        seed: Random seed for reproducibility.
+
+    Returns:
+        Pandas Series of returns exhibiting volatility clustering.
+    """
+    rng = np.random.default_rng(seed)
+    z = rng.standard_normal(n)
+    data = np.zeros(n, dtype=np.float64)
+    sigma = np.zeros(n, dtype=np.float64)
+    sigma[0] = 0.01
+    data[0] = sigma[0] * z[0]
+    for i in range(1, n):
+        sigma[i] = 0.005 + 0.8 * abs(data[i - 1])
+        data[i] = sigma[i] * z[i]
+    return pd.Series(data, dtype=np.float64, name="garch_return")
+
+
+def make_causal_pair(
+    n: int = 500,
+    lag: int = 1,
+    seed: int = 42,
+) -> tuple[pd.Series, pd.Series]:  # type: ignore[type-arg]
+    """Generate a pair of return series where X Granger-causes Y.
+
+    ``Y_t = alpha * X_{t-lag} + noise``.
+
+    Args:
+        n: Number of return observations.
+        lag: Lag order of the causal relationship.
+        seed: Random seed for reproducibility.
+
+    Returns:
+        Tuple of ``(X, Y)`` Pandas Series.
+    """
+    rng = np.random.default_rng(seed)
+    x = rng.normal(loc=0.0, scale=0.01, size=n)
+    noise = rng.normal(loc=0.0, scale=0.005, size=n)
+    y = np.zeros(n, dtype=np.float64)
+    for i in range(lag, n):
+        y[i] = 0.5 * x[i - lag] + noise[i]
+    return (
+        pd.Series(x, dtype=np.float64, name="X"),
+        pd.Series(y, dtype=np.float64, name="Y"),
+    )

--- a/src/tests/profiling/test_serial_dependence.py
+++ b/src/tests/profiling/test_serial_dependence.py
@@ -1,0 +1,479 @@
+"""Tests for SerialDependenceAnalyzer against synthetic time series.
+
+Verifies ACF/PACF computation, multi-lag Ljung-Box tests, Lo-MacKinlay
+variance ratio with Chow-Denning, Granger causality, and tier-gated
+behaviour.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd  # type: ignore[import-untyped]
+import pytest
+
+from src.app.profiling.application.serial_dependence import SerialDependenceAnalyzer
+from src.app.profiling.domain.value_objects import (
+    AutocorrelationConfig,
+    SampleTier,
+)
+from src.tests.profiling.conftest import (
+    make_ar1_returns,
+    make_causal_pair,
+    make_garch_like_returns,
+    make_random_walk_returns,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _default_config() -> AutocorrelationConfig:
+    """Return a default AutocorrelationConfig for tests."""
+    return AutocorrelationConfig()
+
+
+def _make_analyzer() -> SerialDependenceAnalyzer:
+    """Return a fresh SerialDependenceAnalyzer instance."""
+    return SerialDependenceAnalyzer()
+
+
+# ---------------------------------------------------------------------------
+# ACF / PACF tests
+# ---------------------------------------------------------------------------
+
+
+class TestACFPACF:
+    """Tests for ACF and PACF computation."""
+
+    def test_acf_white_noise(self) -> None:
+        """White noise returns: ACF values near 0 for lag > 0."""
+        returns = make_random_walk_returns(n=2000, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A, bars_per_day=24.0)
+
+        # Lag 0 ACF should be 1.0
+        assert abs(profile.acf_values[0] - 1.0) < 1e-10
+        # Remaining lags should be near zero (within 2/sqrt(n) ~ 0.045)
+        threshold = 3.0 / np.sqrt(len(returns))
+        for lag_idx in range(1, len(profile.acf_values)):
+            assert abs(profile.acf_values[lag_idx]) < threshold
+
+    def test_acf_ar1_process(self) -> None:
+        """AR(1) with phi=0.5: ACF at lag 1 should be approximately 0.5."""
+        returns = make_ar1_returns(n=5000, phi=0.5, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A, bars_per_day=24.0)
+
+        assert abs(profile.acf_values[1] - 0.5) < 0.1
+
+    def test_pacf_ar1_process(self) -> None:
+        """AR(1) with phi=0.5: PACF at lag 1 ~0.5, lags > 1 near 0."""
+        returns = make_ar1_returns(n=5000, phi=0.5, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A, bars_per_day=24.0)
+
+        # PACF at lag 1 should be near phi
+        assert abs(profile.pacf_values[1] - 0.5) < 0.1
+        # PACF at higher lags should be near 0 for AR(1)
+        threshold = 3.0 / np.sqrt(len(returns))
+        for lag_idx in range(2, min(6, len(profile.pacf_values))):
+            assert abs(profile.pacf_values[lag_idx]) < threshold
+
+    def test_acf_max_lag_capped(self) -> None:
+        """When data is short, max_lag auto-caps to n//2 - 1."""
+        # With n=20, max_lag should cap at 9 (20//2 - 1)
+        returns = make_random_walk_returns(n=20, seed=42)
+        config = AutocorrelationConfig(max_lag=40)
+        profile = _make_analyzer().analyze(
+            returns, "BTCUSDT", "dollar", SampleTier.A, bars_per_day=24.0, config=config
+        )
+
+        # ACF array includes lag 0, so length = effective_lag + 1
+        expected_max_lag = 20 // 2 - 1  # = 9
+        assert len(profile.acf_values) == expected_max_lag + 1
+
+
+# ---------------------------------------------------------------------------
+# Ljung-Box tests
+# ---------------------------------------------------------------------------
+
+
+class TestLjungBox:
+    """Tests for multi-lag Ljung-Box testing."""
+
+    def test_ljung_box_white_noise(self) -> None:
+        """White noise: no significant lags expected."""
+        returns = make_random_walk_returns(n=2000, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A, bars_per_day=24.0)
+
+        assert profile.has_serial_correlation is False
+        for lb in profile.ljung_box_returns:
+            assert lb.significant is False
+
+    def test_ljung_box_ar1(self) -> None:
+        """AR(1) phi=0.3: should detect serial correlation at lag 5."""
+        returns = make_ar1_returns(n=2000, phi=0.3, seed=42)
+        config = AutocorrelationConfig(ljung_box_lags=(5,))
+        profile = _make_analyzer().analyze(
+            returns, "BTCUSDT", "dollar", SampleTier.A, bars_per_day=24.0, config=config
+        )
+
+        assert len(profile.ljung_box_returns) == 1
+        assert profile.ljung_box_returns[0].lag == 5
+        assert profile.ljung_box_returns[0].significant is True
+        assert profile.has_serial_correlation is True
+
+    def test_ljung_box_multiple_lags(self) -> None:
+        """Returns one result per requested lag."""
+        returns = make_random_walk_returns(n=2000, seed=42)
+        config = AutocorrelationConfig(ljung_box_lags=(5, 10, 20))
+        profile = _make_analyzer().analyze(
+            returns, "BTCUSDT", "dollar", SampleTier.A, bars_per_day=24.0, config=config
+        )
+
+        assert len(profile.ljung_box_returns) == 3
+        result_lags = [r.lag for r in profile.ljung_box_returns]
+        assert result_lags == [5, 10, 20]
+
+    def test_ljung_box_squared_returns_garch(self) -> None:
+        """GARCH-like squared returns should show significance."""
+        returns = make_garch_like_returns(n=2000, seed=42)
+        config = AutocorrelationConfig(ljung_box_lags=(5, 10))
+        profile = _make_analyzer().analyze(
+            returns, "BTCUSDT", "dollar", SampleTier.A, bars_per_day=24.0, config=config
+        )
+
+        assert profile.has_volatility_clustering is True
+        # At least one LB on squared returns should be significant
+        assert any(lb.significant for lb in profile.ljung_box_squared)
+
+
+# ---------------------------------------------------------------------------
+# Variance ratio tests
+# ---------------------------------------------------------------------------
+
+
+class TestVarianceRatio:
+    """Tests for Lo-MacKinlay variance ratio and Chow-Denning."""
+
+    def test_vr_random_walk(self) -> None:
+        """Random walk: VR approximately 1.0 at all horizons, not significant."""
+        returns = make_random_walk_returns(n=5000, seed=42)
+        config = AutocorrelationConfig(vr_calendar_horizons_days=(1.0, 3.0, 7.0))
+        profile = _make_analyzer().analyze(
+            returns, "BTCUSDT", "dollar", SampleTier.A, bars_per_day=24.0, config=config
+        )
+
+        assert profile.vr_results is not None
+        for vr in profile.vr_results:
+            assert abs(vr.variance_ratio - 1.0) < 0.15
+
+    def test_vr_mean_reverting(self) -> None:
+        """Mean-reverting (AR(1) negative phi): VR < 1 at longer horizons."""
+        returns = make_ar1_returns(n=5000, phi=-0.3, seed=42)
+        config = AutocorrelationConfig(vr_calendar_horizons_days=(3.0, 7.0))
+        profile = _make_analyzer().analyze(
+            returns, "BTCUSDT", "dollar", SampleTier.A, bars_per_day=24.0, config=config
+        )
+
+        assert profile.vr_results is not None
+        # With negative autocorrelation, VR should be < 1
+        for vr in profile.vr_results:
+            assert vr.variance_ratio < 1.0
+
+    def test_vr_trending(self) -> None:
+        """Trending (AR(1) positive phi): VR > 1."""
+        returns = make_ar1_returns(n=5000, phi=0.3, seed=42)
+        config = AutocorrelationConfig(vr_calendar_horizons_days=(3.0, 7.0))
+        profile = _make_analyzer().analyze(
+            returns, "BTCUSDT", "dollar", SampleTier.A, bars_per_day=24.0, config=config
+        )
+
+        assert profile.vr_results is not None
+        for vr in profile.vr_results:
+            assert vr.variance_ratio > 1.0
+
+    def test_vr_tier_b_caps_horizon(self) -> None:
+        """Tier B skips horizons beyond 7 days."""
+        returns = make_random_walk_returns(n=5000, seed=42)
+        config = AutocorrelationConfig(vr_calendar_horizons_days=(1.0, 7.0, 14.0))
+        profile = _make_analyzer().analyze(
+            returns, "BTCUSDT", "dollar", SampleTier.B, bars_per_day=24.0, config=config
+        )
+
+        assert profile.vr_results is not None
+        # 14-day horizon should be excluded for Tier B
+        cal_horizons = [vr.calendar_horizon_days for vr in profile.vr_results]
+        assert 14.0 not in cal_horizons
+        assert 1.0 in cal_horizons
+        assert 7.0 in cal_horizons
+
+    def test_vr_tier_c_skipped(self) -> None:
+        """Tier C gets None for VR results."""
+        returns = make_random_walk_returns(n=100, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.C, bars_per_day=24.0)
+
+        assert profile.vr_results is None
+        assert profile.chow_denning_stat is None
+        assert profile.chow_denning_pvalue is None
+
+    def test_chow_denning_stat(self) -> None:
+        """Chow-Denning stat is max(|z_i|) across all tested horizons."""
+        returns = make_ar1_returns(n=5000, phi=0.3, seed=42)
+        config = AutocorrelationConfig(vr_calendar_horizons_days=(1.0, 3.0, 7.0))
+        profile = _make_analyzer().analyze(
+            returns, "BTCUSDT", "dollar", SampleTier.A, bars_per_day=24.0, config=config
+        )
+
+        assert profile.vr_results is not None
+        assert profile.chow_denning_stat is not None
+        assert profile.chow_denning_pvalue is not None
+
+        # CD stat should be max of absolute z-statistics
+        max_abs_z = max(abs(vr.z_statistic) for vr in profile.vr_results)
+        assert abs(profile.chow_denning_stat - max_abs_z) < 1e-10
+
+        # p-value should be in [0, 1]
+        assert 0.0 <= profile.chow_denning_pvalue <= 1.0
+
+    def test_calendar_to_bar_conversion(self) -> None:
+        """Correct conversion with known bars_per_day."""
+        returns = make_random_walk_returns(n=5000, seed=42)
+        config = AutocorrelationConfig(vr_calendar_horizons_days=(1.0,))
+        # 24 bars/day -> 1-day horizon = 24 bars
+        profile = _make_analyzer().analyze(
+            returns, "BTCUSDT", "dollar", SampleTier.A, bars_per_day=24.0, config=config
+        )
+
+        assert profile.vr_results is not None
+        assert len(profile.vr_results) == 1
+        assert profile.vr_results[0].bar_count_q == 24
+
+
+# ---------------------------------------------------------------------------
+# Granger causality tests
+# ---------------------------------------------------------------------------
+
+
+class TestGrangerCausality:
+    """Tests for Granger causality testing."""
+
+    def test_granger_causal_relationship(self) -> None:
+        """Constructed X->Y causal relationship should be detected."""
+        x, y = make_causal_pair(n=1000, lag=1, seed=42)
+        analyzer = _make_analyzer()
+        results = analyzer.test_granger_pairs(
+            returns_dict={"X": x, "Y": y},
+            lags=(1, 2),
+            alpha=0.05,
+        )
+
+        # X -> Y should be significant at lag 1
+        x_to_y_lag1 = [r for r in results if r.source_name == "X" and r.target_name == "Y" and r.lag == 1]
+        assert len(x_to_y_lag1) == 1
+        assert x_to_y_lag1[0].significant is True
+
+    def test_granger_independent(self) -> None:
+        """Independent series should not detect Granger causality."""
+        rng = np.random.default_rng(42)
+        x = pd.Series(rng.normal(0, 0.01, 1000), dtype=np.float64, name="X")
+        y = pd.Series(rng.normal(0, 0.01, 1000), dtype=np.float64, name="Y")
+
+        analyzer = _make_analyzer()
+        results = analyzer.test_granger_pairs(
+            returns_dict={"X": x, "Y": y},
+            lags=(1, 2, 4),
+            alpha=0.05,
+        )
+
+        # With independent series, most tests should not be significant
+        # (allow for one false positive at 5% level)
+        n_significant = sum(1 for r in results if r.significant)
+        assert n_significant <= 2
+
+    def test_granger_tier_a_only(self) -> None:
+        """Tier B/C should get None for granger_results in the profile."""
+        returns = make_random_walk_returns(n=2000, seed=42)
+        profile_b = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.B, bars_per_day=24.0)
+        profile_c = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.C, bars_per_day=24.0)
+
+        assert profile_b.granger_results is None
+        assert profile_c.granger_results is None
+
+    def test_granger_pairs_all_combinations(self) -> None:
+        """test_granger_pairs covers all ordered pairs."""
+        rng = np.random.default_rng(99)
+        series_dict = {
+            "A": pd.Series(rng.normal(0, 0.01, 500), dtype=np.float64),
+            "B": pd.Series(rng.normal(0, 0.01, 500), dtype=np.float64),
+            "C": pd.Series(rng.normal(0, 0.01, 500), dtype=np.float64),
+        }
+        analyzer = _make_analyzer()
+        results = analyzer.test_granger_pairs(
+            returns_dict=series_dict,
+            lags=(1,),
+            alpha=0.05,
+        )
+
+        # 3 assets -> 6 ordered pairs, 1 lag each -> 6 results
+        assert len(results) == 6
+        pairs = {(r.source_name, r.target_name) for r in results}
+        expected_pairs = {
+            ("A", "B"),
+            ("A", "C"),
+            ("B", "A"),
+            ("B", "C"),
+            ("C", "A"),
+            ("C", "B"),
+        }
+        assert pairs == expected_pairs
+
+
+# ---------------------------------------------------------------------------
+# Full profile tests
+# ---------------------------------------------------------------------------
+
+
+class TestFullProfile:
+    """Tests for the complete analyze() output."""
+
+    def test_analyze_tier_a_full_profile(self) -> None:
+        """Tier A returns all non-Granger fields populated."""
+        returns = make_ar1_returns(n=5000, phi=0.2, seed=42)
+        config = AutocorrelationConfig(
+            ljung_box_lags=(5, 10),
+            vr_calendar_horizons_days=(1.0, 3.0),
+        )
+        profile = _make_analyzer().analyze(
+            returns, "BTCUSDT", "dollar", SampleTier.A, bars_per_day=24.0, config=config
+        )
+
+        # Metadata
+        assert profile.asset == "BTCUSDT"
+        assert profile.bar_type == "dollar"
+        assert profile.tier == SampleTier.A
+        assert profile.n_observations == 5000
+
+        # ACF / PACF populated
+        assert len(profile.acf_values) > 0
+        assert len(profile.pacf_values) > 0
+        assert len(profile.acf_squared_values) > 0
+        assert len(profile.pacf_squared_values) > 0
+
+        # Ljung-Box populated
+        assert len(profile.ljung_box_returns) == 2
+        assert len(profile.ljung_box_squared) == 2
+
+        # VR populated
+        assert profile.vr_results is not None
+        assert len(profile.vr_results) == 2
+        assert profile.chow_denning_stat is not None
+        assert profile.chow_denning_pvalue is not None
+
+    def test_analyze_tier_c_minimal(self) -> None:
+        """Tier C: only ACF + Ljung-Box, no VR or Granger."""
+        returns = make_random_walk_returns(n=100, seed=42)
+        config = AutocorrelationConfig(ljung_box_lags=(5,))
+        profile = _make_analyzer().analyze(
+            returns, "BTCUSDT", "dollar", SampleTier.C, bars_per_day=24.0, config=config
+        )
+
+        # ACF / PACF should still be present
+        assert len(profile.acf_values) > 0
+        assert len(profile.pacf_values) > 0
+
+        # VR and Granger should be None
+        assert profile.vr_results is None
+        assert profile.chow_denning_stat is None
+        assert profile.chow_denning_pvalue is None
+        assert profile.granger_results is None
+
+    def test_deterministic_output(self) -> None:
+        """Same input produces same output."""
+        returns = make_ar1_returns(n=1000, phi=0.3, seed=123)
+        config = AutocorrelationConfig(
+            ljung_box_lags=(5, 10),
+            vr_calendar_horizons_days=(1.0,),
+        )
+        analyzer = _make_analyzer()
+
+        profile_1 = analyzer.analyze(returns, "BTCUSDT", "dollar", SampleTier.A, bars_per_day=24.0, config=config)
+        profile_2 = analyzer.analyze(returns, "BTCUSDT", "dollar", SampleTier.A, bars_per_day=24.0, config=config)
+
+        # Compare scalar fields
+        assert profile_1.asset == profile_2.asset
+        assert profile_1.n_observations == profile_2.n_observations
+        assert profile_1.has_serial_correlation == profile_2.has_serial_correlation
+        assert profile_1.has_volatility_clustering == profile_2.has_volatility_clustering
+        assert profile_1.ljung_box_returns == profile_2.ljung_box_returns
+        assert profile_1.ljung_box_squared == profile_2.ljung_box_squared
+        assert profile_1.vr_results == profile_2.vr_results
+        assert profile_1.chow_denning_stat == profile_2.chow_denning_stat
+
+        # Compare numpy arrays
+        np.testing.assert_array_equal(profile_1.acf_values, profile_2.acf_values)
+        np.testing.assert_array_equal(profile_1.pacf_values, profile_2.pacf_values)
+
+
+# ---------------------------------------------------------------------------
+# Value object construction tests
+# ---------------------------------------------------------------------------
+
+
+class TestValueObjects:
+    """Tests for value object construction and constraints."""
+
+    def test_autocorrelation_config_defaults(self) -> None:
+        """Default config should have sensible defaults."""
+        config = AutocorrelationConfig()
+        assert config.max_lag == 40
+        assert config.ljung_box_lags == (5, 10, 20, 40)
+        assert config.alpha == 0.05
+        assert config.granger_max_lags == (1, 2, 4, 8)
+        assert config.vr_calendar_horizons_days == (1.0, 3.0, 7.0, 14.0)
+        assert config.vr_robust is True
+
+    def test_autocorrelation_config_frozen(self) -> None:
+        """AutocorrelationConfig should be immutable."""
+        from pydantic import ValidationError
+
+        config = AutocorrelationConfig()
+        with pytest.raises(ValidationError):
+            config.max_lag = 100  # type: ignore[misc]
+
+    def test_ljung_box_result_construction(self) -> None:
+        """LjungBoxResult should be constructable with valid data."""
+        from src.app.profiling.domain.value_objects import LjungBoxResult
+
+        result = LjungBoxResult(lag=5, q_statistic=10.5, p_value=0.03, significant=True)
+        assert result.lag == 5
+        assert result.significant is True
+
+    def test_variance_ratio_result_construction(self) -> None:
+        """VarianceRatioResult should be constructable with valid data."""
+        from src.app.profiling.domain.value_objects import VarianceRatioResult
+
+        result = VarianceRatioResult(
+            calendar_horizon_days=7.0,
+            bar_count_q=168,
+            variance_ratio=0.85,
+            z_statistic=-2.1,
+            p_value=0.036,
+            significant=True,
+        )
+        assert result.bar_count_q == 168
+        assert result.significant is True
+
+    def test_granger_result_construction(self) -> None:
+        """GrangerResult should be constructable with valid data."""
+        from src.app.profiling.domain.value_objects import GrangerResult
+
+        result = GrangerResult(
+            source_name="BTCUSDT_returns",
+            target_name="ETHUSDT_returns",
+            lag=1,
+            f_statistic=5.2,
+            p_value=0.023,
+            significant=True,
+        )
+        assert result.source_name == "BTCUSDT_returns"
+        assert result.significant is True


### PR DESCRIPTION
## Summary

- Add **SerialDependenceAnalyzer** service with tier-gated autocorrelation, variance ratio, and Granger causality analysis
- Add 6 domain value objects: `AutocorrelationConfig`, `LjungBoxResult`, `VarianceRatioResult`, `GrangerResult`, `AutocorrelationProfile` to `profiling/domain/value_objects.py`
- Add 4 test data factories (`make_ar1_returns`, `make_random_walk_returns`, `make_garch_like_returns`, `make_causal_pair`) to profiling conftest
- **27 new tests** covering ACF/PACF, multi-lag Ljung-Box, Lo-MacKinlay variance ratio with Chow-Denning, Granger causality, tier gating, and deterministic output

### Tier gating

| Analysis | Tier A | Tier B | Tier C |
|----------|--------|--------|--------|
| ACF/PACF (raw + squared) | Yes | Yes | Yes |
| Multi-lag Ljung-Box | Yes | Yes | Yes |
| Lo-MacKinlay Variance Ratio | All horizons | Capped at 7d | None |
| Chow-Denning joint test | Yes | Yes | None |
| Granger causality | Yes | None | None |

### Key implementation details

- `arch.unitroot.VarianceRatio` expects **price levels** (cumulative sum), not returns -- converts internally
- Calendar-day horizons are converted to bar counts via `bars_per_day` parameter, with deduplication for low-frequency bars
- Chow-Denning p-value uses Sidak correction: `1 - (1 - 2*(1 - Phi(|z_max|)))^n_tests`
- Granger uses SSR F-test from `statsmodels.tsa.stattools.grangercausalitytests`

## Test plan

- [x] `just test src/tests/profiling/` -- all 100 profiling tests pass
- [x] `just test` -- all 773 project tests pass
- [x] `just lint` -- ruff format + ruff lint + pyright clean (pre-existing pyright error in `repository.py` is unrelated)
- [x] Pre-commit hooks pass on commit

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)