### PR TITLE
feat(profiling): add Phase 5D predictability assessment

### DIFF
--- a/src/app/profiling/application/predictability.py
+++ b/src/app/profiling/application/predictability.py
@@ -1,0 +1,558 @@
+"""Predictability assessment via permutation entropy, effective sample size, and signal-to-noise analysis."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd  # type: ignore[import-untyped]
+from loguru import logger
+from scipy.stats import norm  # type: ignore[import-untyped]
+from sklearn.linear_model import Ridge  # type: ignore[import-untyped]
+from statsmodels.tsa.stattools import acf  # type: ignore[import-untyped]
+
+from src.app.profiling.domain.value_objects import (
+    PermutationEntropyResult,
+    PredictabilityConfig,
+    PredictabilityProfile,
+    SampleTier,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_MIN_SAMPLES_ACF: int = 2
+"""Minimum observations required for ACF-based N_eff computation."""
+
+_MIN_SPLIT_SAMPLES: int = 2
+"""Minimum observations in train or test partition for Ridge SNR."""
+
+_MIN_FEATURES: int = 1
+"""Minimum number of features for Ridge SNR computation."""
+
+
+# ---------------------------------------------------------------------------
+# Internal computation helpers
+# ---------------------------------------------------------------------------
+
+
+def _shannon_entropy(p: np.ndarray) -> float:  # type: ignore[type-arg]
+    """Compute Shannon entropy H(p) in natural logarithm (nats).
+
+    Ignores zero-probability entries to avoid log(0).
+
+    Args:
+        p: Probability distribution array (must sum to 1).
+
+    Returns:
+        Shannon entropy value (>= 0).
+    """
+    mask: np.ndarray = p > 0  # type: ignore[type-arg]
+    return -float(np.sum(p[mask] * np.log(p[mask])))
+
+
+def _compute_permutation_entropy(  # noqa: PLR0914
+    data: np.ndarray,  # type: ignore[type-arg]
+    d: int,
+    tau: int,
+) -> tuple[float, float]:
+    """Compute normalized permutation entropy and Jensen-Shannon complexity.
+
+    Implements the Bandt & Pompe (2002) ordinal pattern method.
+
+    Args:
+        data: 1-D array of observations (e.g. log returns).
+        d: Embedding dimension (number of elements per ordinal pattern).
+        tau: Time delay between consecutive elements in patterns.
+
+    Returns:
+        Tuple of ``(normalized_entropy, js_complexity)``.
+    """
+    n: int = len(data)
+    n_factorial: int = math.factorial(d)
+    max_entropy: float = math.log(n_factorial)
+
+    # Number of valid patterns
+    pattern_length: int = (d - 1) * tau + 1
+    n_patterns: int = n - pattern_length + 1
+
+    if n_patterns <= 0 or max_entropy == 0.0:
+        return 1.0, 0.0
+
+    # Extract ordinal patterns: rank order via argsort of argsort
+    # Build index array for subsequences with delay tau
+    indices: np.ndarray = np.arange(d)[np.newaxis, :] * tau + np.arange(n_patterns)[:, np.newaxis]  # type: ignore[type-arg]
+    subsequences: np.ndarray = data[indices]  # type: ignore[type-arg]
+
+    # Convert each subsequence to its ordinal rank pattern
+    ranks: np.ndarray = np.argsort(np.argsort(subsequences, axis=1), axis=1)  # type: ignore[type-arg]
+
+    # Convert rank tuples to unique integers for counting
+    # Use a base-(d) positional encoding: sum(rank[i] * d^i)
+    multipliers: np.ndarray = np.array([d**i for i in range(d)], dtype=np.int64)  # type: ignore[type-arg]
+    pattern_ids: np.ndarray = ranks @ multipliers  # type: ignore[type-arg]
+
+    # Count occurrences of each pattern
+    unique_ids: np.ndarray  # type: ignore[type-arg]
+    counts: np.ndarray  # type: ignore[type-arg]
+    unique_ids, counts = np.unique(pattern_ids, return_counts=True)
+
+    # Probability distribution over observed patterns
+    p: np.ndarray = counts.astype(np.float64) / n_patterns  # type: ignore[type-arg]
+
+    # Shannon entropy of observed distribution
+    h: float = _shannon_entropy(p)
+    h_norm: float = h / max_entropy if max_entropy > 0 else 1.0
+    h_norm = max(0.0, min(1.0, h_norm))
+
+    # Jensen-Shannon complexity
+    uniform: np.ndarray = np.full(n_factorial, 1.0 / n_factorial, dtype=np.float64)  # type: ignore[type-arg]
+
+    # Pad observed distribution to full d! support
+    p_full: np.ndarray = np.zeros(n_factorial, dtype=np.float64)  # type: ignore[type-arg]
+    # Map unique_ids back to indices in the full distribution
+    # Since pattern_ids are unique integers, use them directly
+    # But they may exceed n_factorial range; we need a mapping
+    # Actually the pattern_ids encode ordinal ranks, and each is unique among d! permutations
+    # We can use a lookup for all d! permutations
+    all_perms: np.ndarray = np.array(  # type: ignore[type-arg]
+        [np.argsort(np.argsort(perm)) @ multipliers for perm in _all_permutations(d)],
+        dtype=np.int64,
+    )
+    perm_to_idx: dict[int, int] = {int(pid): idx for idx, pid in enumerate(all_perms)}
+    for uid, cnt in zip(unique_ids, counts, strict=True):
+        idx: int = perm_to_idx.get(int(uid), 0)
+        p_full[idx] = float(cnt) / n_patterns
+
+    # JS divergence: D_JS(p || u) = H((p+u)/2) - (H(p) + H(u))/2
+    m: np.ndarray = (p_full + uniform) / 2.0  # type: ignore[type-arg]
+    h_uniform: float = math.log(n_factorial)
+    h_p_full: float = _shannon_entropy(p_full)
+    h_m: float = _shannon_entropy(m)
+    js_div: float = h_m - (h_p_full + h_uniform) / 2.0
+    js_div = max(0.0, js_div)
+
+    # Maximum JS divergence: between delta distribution and uniform
+    delta: np.ndarray = np.zeros(n_factorial, dtype=np.float64)  # type: ignore[type-arg]
+    delta[0] = 1.0
+    m0: np.ndarray = (delta + uniform) / 2.0  # type: ignore[type-arg]
+    h_delta: float = 0.0  # entropy of delta is 0
+    h_m0: float = _shannon_entropy(m0)
+    js_div_max: float = h_m0 - (h_delta + h_uniform) / 2.0
+    js_div_max = max(js_div_max, 1e-15)  # avoid division by zero
+
+    # Statistical complexity: C = (js_div / js_div_max) * H_norm
+    js_complexity: float = (js_div / js_div_max) * h_norm
+    js_complexity = max(0.0, js_complexity)
+
+    return h_norm, js_complexity
+
+
+def _all_permutations(d: int) -> list[list[int]]:
+    """Generate all permutations of range(d).
+
+    Args:
+        d: Number of elements to permute.
+
+    Returns:
+        List of all d! permutations, each as a list of integers.
+    """
+    if d <= 1:
+        return [[0]] if d == 1 else [[]]
+    result: list[list[int]] = []
+    _permute_helper(list(range(d)), 0, d, result)
+    return result
+
+
+def _permute_helper(
+    arr: list[int],
+    start: int,
+    n: int,
+    result: list[list[int]],
+) -> None:
+    """Recursive helper for generating permutations in-place.
+
+    Args:
+        arr: Current permutation being built.
+        start: Index from which to start swapping.
+        n: Total number of elements.
+        result: Accumulator list for completed permutations.
+    """
+    if start == n:
+        result.append(arr[:])
+        return
+    for i in range(start, n):
+        arr[start], arr[i] = arr[i], arr[start]
+        _permute_helper(arr, start + 1, n, result)
+        arr[start], arr[i] = arr[i], arr[start]
+
+
+def _compute_kish_neff(
+    returns: np.ndarray,  # type: ignore[type-arg]
+    max_lag_fraction: float,
+) -> tuple[float, float]:
+    """Compute Kish effective sample size from autocorrelation structure.
+
+    Uses the Bartlett bandwidth truncation: sum stops when
+    ``|rho_k| < 1.96 / sqrt(N)`` (insignificant at 5% level).
+
+    Args:
+        returns: 1-D array of return observations.
+        max_lag_fraction: Maximum lag as fraction of N.
+
+    Returns:
+        Tuple of ``(n_eff, n_eff_ratio)`` where n_eff_ratio = n_eff / N.
+    """
+    n: int = len(returns)
+    if n < _MIN_SAMPLES_ACF:
+        return float(n), 1.0
+
+    max_lag: int = max(1, int(n * max_lag_fraction))
+    # Cap at n//2 - 1 to keep ACF well-defined
+    max_lag = min(max_lag, n // 2 - 1)
+    if max_lag < 1:
+        return float(n), 1.0
+
+    # Compute ACF (statsmodels returns values only when alpha is not specified)
+    acf_values: np.ndarray = acf(returns, nlags=max_lag, fft=True, alpha=None)  # type: ignore[type-arg]
+
+    # Bartlett significance threshold
+    bartlett_threshold: float = 1.96 / math.sqrt(n)
+
+    # Sum autocorrelations with Bartlett truncation
+    acf_sum: float = 0.0
+    for k in range(1, max_lag + 1):
+        rho_k: float = float(acf_values[k])
+        if abs(rho_k) < bartlett_threshold:
+            break
+        acf_sum += rho_k
+
+    # Kish formula: N_eff = N / (1 + 2 * sum(rho_k))
+    denominator: float = 1.0 + 2.0 * acf_sum
+    if denominator <= 0:
+        denominator = 1.0
+
+    n_eff: float = float(n) / denominator
+    # Clamp to [1, N]
+    n_eff = max(1.0, min(float(n), n_eff))
+    n_eff_ratio: float = n_eff / float(n)
+
+    return n_eff, n_eff_ratio
+
+
+def _compute_mde_da(
+    n_eff: float,
+    alpha: float,
+    power: float,
+) -> float:
+    """Compute minimum detectable directional accuracy above 0.50.
+
+    Uses normal approximation to the binomial distribution for
+    a one-sided test.
+
+    Args:
+        n_eff: Effective sample size.
+        alpha: Significance level.
+        power: Statistical power.
+
+    Returns:
+        Minimum detectable DA (in [0.5, 1.0]).
+    """
+    if n_eff <= 0:
+        return 1.0
+
+    z_alpha: float = float(norm.ppf(1.0 - alpha))
+    z_beta: float = float(norm.ppf(power))
+    mde: float = (z_alpha + z_beta) / (2.0 * math.sqrt(n_eff))
+    result: float = 0.5 + mde
+
+    # Clamp to [0.5, 1.0]
+    return max(0.5, min(1.0, result))
+
+
+def _compute_breakeven_da(
+    mean_abs_return: float,
+    round_trip_cost: float,
+) -> float:
+    """Compute break-even directional accuracy from transaction costs.
+
+    Solves: ``(2p - 1) * mean(|r_t|) = round_trip_cost`` for p.
+
+    Args:
+        mean_abs_return: Mean absolute return per bar.
+        round_trip_cost: Round-trip transaction cost.
+
+    Returns:
+        Break-even DA (in [0.5, 1.0]).
+    """
+    if mean_abs_return <= 0:
+        return 1.0
+
+    p: float = 0.5 + round_trip_cost / (2.0 * mean_abs_return)
+
+    # Clamp to [0.5, 1.0]
+    return max(0.5, min(1.0, p))
+
+
+def _compute_snr_r2(  # noqa: PLR0913, PLR0917
+    features: np.ndarray,  # type: ignore[type-arg]
+    target: np.ndarray,  # type: ignore[type-arg]
+    holdout_fraction: float,
+    ridge_alpha: float,
+    n_noise_baselines: int,
+    seed: int,
+) -> tuple[float, float]:
+    """Compute adjusted R-squared from Ridge regression on temporal holdout.
+
+    Fits Ridge on the first ``(1 - holdout_fraction)`` of the data,
+    evaluates on the last ``holdout_fraction``.  Compares against
+    random Gaussian features as a noise baseline.
+
+    Args:
+        features: Feature matrix of shape ``(n_samples, n_features)``.
+        target: Target array of shape ``(n_samples,)``.
+        holdout_fraction: Fraction of data for temporal holdout.
+        ridge_alpha: Ridge regularization parameter.
+        n_noise_baselines: Number of random-feature baseline runs.
+        seed: Random seed for reproducibility.
+
+    Returns:
+        Tuple of ``(adjusted_r2, mean_noise_r2)``.
+    """
+    n: int = len(target)
+    n_features: int = features.shape[1]
+    split_idx: int = int(n * (1.0 - holdout_fraction))
+
+    if split_idx < _MIN_SPLIT_SAMPLES or (n - split_idx) < _MIN_SPLIT_SAMPLES or n_features < _MIN_FEATURES:
+        return 0.0, 0.0
+
+    # Temporal split
+    x_train: np.ndarray = features[:split_idx]  # type: ignore[type-arg]
+    x_test: np.ndarray = features[split_idx:]  # type: ignore[type-arg]
+    y_train: np.ndarray = target[:split_idx]  # type: ignore[type-arg]
+    y_test: np.ndarray = target[split_idx:]  # type: ignore[type-arg]
+
+    n_test: int = len(y_test)
+
+    # Fit real features
+    adj_r2: float = _fit_ridge_adj_r2(x_train, y_train, x_test, y_test, ridge_alpha, n_features, n_test)
+
+    # Noise baselines
+    rng: np.random.Generator = np.random.default_rng(seed)
+    noise_r2_values: list[float] = []
+    for _ in range(n_noise_baselines):
+        noise_train: np.ndarray = rng.normal(0, 1, size=(split_idx, n_features))  # type: ignore[type-arg]
+        noise_test: np.ndarray = rng.normal(0, 1, size=(n_test, n_features))  # type: ignore[type-arg]
+        noise_r2: float = _fit_ridge_adj_r2(noise_train, y_train, noise_test, y_test, ridge_alpha, n_features, n_test)
+        noise_r2_values.append(noise_r2)
+
+    mean_noise_r2: float = float(np.mean(noise_r2_values))
+
+    return adj_r2, mean_noise_r2
+
+
+def _fit_ridge_adj_r2(  # noqa: PLR0913, PLR0917
+    x_train: np.ndarray,  # type: ignore[type-arg]
+    y_train: np.ndarray,  # type: ignore[type-arg]
+    x_test: np.ndarray,  # type: ignore[type-arg]
+    y_test: np.ndarray,  # type: ignore[type-arg]
+    ridge_alpha: float,
+    n_features: int,
+    n_test: int,
+) -> float:
+    """Fit Ridge regression and compute adjusted R-squared on test set.
+
+    Args:
+        x_train: Training feature matrix.
+        y_train: Training target array.
+        x_test: Test feature matrix.
+        y_test: Test target array.
+        ridge_alpha: Ridge regularization parameter.
+        n_features: Number of features (for adjusted R² denominator).
+        n_test: Number of test observations.
+
+    Returns:
+        Adjusted R-squared value (can be negative on holdout).
+    """
+    model: Ridge = Ridge(alpha=ridge_alpha)
+    model.fit(x_train, y_train)
+
+    y_pred: np.ndarray = model.predict(x_test)  # type: ignore[type-arg]
+
+    ss_res: float = float(np.sum((y_test - y_pred) ** 2))
+    ss_tot: float = float(np.sum((y_test - np.mean(y_test)) ** 2))
+
+    if ss_tot == 0:
+        return 0.0
+
+    r2: float = 1.0 - ss_res / ss_tot
+
+    # Adjusted R²: penalize for number of features
+    denominator: int = n_test - n_features - 1
+    if denominator <= 0:
+        return r2
+
+    adj_r2: float = 1.0 - (1.0 - r2) * (n_test - 1) / denominator
+
+    # Clamp to [-1.0, 1.0]
+    return max(-1.0, min(1.0, adj_r2))
+
+
+# ---------------------------------------------------------------------------
+# Public analyzer class
+# ---------------------------------------------------------------------------
+
+
+class PredictabilityAnalyzer:
+    """Stateless service for predictability assessment.
+
+    Computes permutation entropy (Bandt & Pompe), Kish effective sample
+    size, minimum detectable effect for directional accuracy, break-even DA
+    from transaction costs, and signal-to-noise ratio via Ridge regression.
+
+    Tier gating:
+        - **Tier A/B:** Permutation entropy, Kish N_eff, MDE DA, breakeven DA.
+        - **Tier A only (+ features):** SNR R-squared from Ridge.
+        - **Tier C:** All analysis fields are None.
+    """
+
+    def analyze(  # noqa: PLR6301, PLR0913, PLR0917, PLR0914
+        self,
+        returns: pd.Series,  # type: ignore[type-arg]
+        asset: str,
+        bar_type: str,
+        tier: SampleTier,
+        config: PredictabilityConfig | None = None,
+        features: np.ndarray | None = None,  # type: ignore[type-arg]
+    ) -> PredictabilityProfile:
+        """Compute a full predictability assessment profile.
+
+        Args:
+            returns: Pandas Series of log returns (NaN-free).
+            asset: Trading pair symbol (e.g. ``"BTCUSDT"``).
+            bar_type: Bar aggregation type (e.g. ``"dollar"``).
+            tier: Sample-size tier controlling analysis depth.
+            config: Predictability analysis configuration.  Uses defaults
+                when ``None``.
+            features: Optional feature matrix ``(n_samples, n_features)``
+                for SNR R-squared computation (Tier A only).
+
+        Returns:
+            Frozen ``PredictabilityProfile`` value object.
+        """
+        if config is None:
+            config = PredictabilityConfig()
+
+        n_obs: int = len(returns)
+        logger.debug(
+            "Analysing predictability: asset={}, bar_type={}, tier={}, n={}",
+            asset,
+            bar_type,
+            tier.value,
+            n_obs,
+        )
+
+        # Insufficient data — return minimal profile
+        if n_obs < config.min_samples_predictability:
+            logger.debug(
+                "Insufficient samples ({} < {}), returning minimal profile",
+                n_obs,
+                config.min_samples_predictability,
+            )
+            return PredictabilityProfile(
+                asset=asset,
+                bar_type=bar_type,
+                tier=tier,
+                n_observations=n_obs,
+            )
+
+        # Tier C — no analysis
+        if tier == SampleTier.C:
+            return PredictabilityProfile(
+                asset=asset,
+                bar_type=bar_type,
+                tier=tier,
+                n_observations=n_obs,
+            )
+
+        returns_arr: np.ndarray = returns.dropna().to_numpy(dtype=np.float64)  # type: ignore[type-arg]
+        n_clean: int = len(returns_arr)
+
+        if n_clean < config.min_samples_predictability:
+            return PredictabilityProfile(
+                asset=asset,
+                bar_type=bar_type,
+                tier=tier,
+                n_observations=n_obs,
+            )
+
+        # Permutation entropy (Tier A/B)
+        pe_results: list[PermutationEntropyResult] = []
+        for d in config.pe_dimensions:
+            h_norm: float
+            js_c: float
+            h_norm, js_c = _compute_permutation_entropy(returns_arr, d, config.pe_delay)
+            pe_results.append(
+                PermutationEntropyResult(
+                    dimension=d,
+                    normalized_entropy=h_norm,
+                    js_complexity=js_c,
+                )
+            )
+        logger.debug("Permutation entropy computed for {} dimensions", len(pe_results))
+
+        # Kish effective sample size (Tier A/B)
+        n_eff: float
+        n_eff_ratio: float
+        n_eff, n_eff_ratio = _compute_kish_neff(returns_arr, config.bartlett_max_lag_fraction)
+        logger.debug("Kish N_eff={:.1f}, ratio={:.3f}", n_eff, n_eff_ratio)
+
+        # Minimum detectable effect for directional accuracy (Tier A/B)
+        mde_da: float = _compute_mde_da(n_eff, config.alpha, config.power)
+        logger.debug("MDE DA={:.4f}", mde_da)
+
+        # Break-even directional accuracy (Tier A/B)
+        mean_abs_ret: float = float(np.mean(np.abs(returns_arr)))
+        breakeven_da: float = _compute_breakeven_da(mean_abs_ret, config.round_trip_cost)
+        logger.debug("Break-even DA={:.4f}", breakeven_da)
+
+        # Signal-to-noise ratio (Tier A only, requires features)
+        snr_r2: float | None = None
+        snr_r2_noise: float | None = None
+        is_predictable: bool | None = None
+
+        if tier == SampleTier.A and features is not None and len(features) >= n_clean:
+            # Align features with cleaned returns
+            features_aligned: np.ndarray = features[:n_clean]  # type: ignore[type-arg]
+            if features_aligned.shape[0] >= config.min_samples_predictability and features_aligned.shape[1] >= 1:
+                snr_r2, snr_r2_noise = _compute_snr_r2(
+                    features_aligned,
+                    returns_arr,
+                    config.snr_holdout_fraction,
+                    config.snr_ridge_alpha,
+                    config.snr_n_noise_baselines,
+                    seed=42,
+                )
+                is_predictable = snr_r2 > snr_r2_noise
+                logger.debug(
+                    "SNR R²={:.4f}, noise baseline={:.4f}, predictable={}",
+                    snr_r2,
+                    snr_r2_noise,
+                    is_predictable,
+                )
+
+        return PredictabilityProfile(
+            asset=asset,
+            bar_type=bar_type,
+            tier=tier,
+            n_observations=n_obs,
+            permutation_entropies=tuple(pe_results),
+            n_eff=n_eff,
+            n_eff_ratio=n_eff_ratio,
+            mde_da=mde_da,
+            breakeven_da=breakeven_da,
+            snr_r2=snr_r2,
+            snr_r2_noise_baseline=snr_r2_noise,
+            is_predictable_vs_noise=is_predictable,
+        )

--- a/src/app/profiling/domain/value_objects.py
+++ b/src/app/profiling/domain/value_objects.py
@@ -696,3 +696,104 @@ class VolatilityProfile(BaseModel, frozen=True):
     regime_labels: np.ndarray | None = None  # type: ignore[type-arg]
     regime_low_threshold: float | None = None
     regime_high_threshold: float | None = None
+
+
+# ---------------------------------------------------------------------------
+# Phase 5D: Predictability assessment value objects
+# ---------------------------------------------------------------------------
+
+
+class PredictabilityConfig(BaseModel, frozen=True):
+    """Configuration for predictability assessment analysis.
+
+    Controls permutation entropy dimensions, statistical power parameters,
+    transaction cost assumptions, and signal-to-noise ratio holdout settings.
+
+    Attributes:
+        pe_dimensions: Embedding dimensions for permutation entropy (Bandt & Pompe).
+        pe_delay: Time delay (tau) for permutation entropy ordinal patterns.
+        alpha: Significance level for MDE computation.
+        power: Statistical power for MDE computation.
+        round_trip_cost: Round-trip transaction cost (Binance spot default 0.2%).
+        snr_holdout_fraction: Fraction of data reserved for SNR temporal holdout.
+        snr_ridge_alpha: Ridge regression regularization strength.
+        snr_n_noise_baselines: Number of random-feature baseline runs for SNR.
+        bartlett_max_lag_fraction: Maximum lag as fraction of N for Kish N_eff Bartlett bandwidth.
+        min_samples_predictability: Minimum samples for any predictability analysis.
+    """
+
+    pe_dimensions: tuple[int, ...] = (3, 4, 5, 6)
+    pe_delay: Annotated[int, PydanticField(ge=1)] = 1
+    alpha: Annotated[float, PydanticField(gt=0, lt=1)] = 0.05
+    power: Annotated[float, PydanticField(gt=0, lt=1)] = 0.80
+    round_trip_cost: Annotated[float, PydanticField(ge=0)] = 0.002
+    snr_holdout_fraction: Annotated[float, PydanticField(gt=0, lt=1)] = 0.30
+    snr_ridge_alpha: Annotated[float, PydanticField(gt=0)] = 1.0
+    snr_n_noise_baselines: Annotated[int, PydanticField(ge=1)] = 10
+    bartlett_max_lag_fraction: Annotated[float, PydanticField(gt=0, lt=1)] = 0.1
+    min_samples_predictability: Annotated[int, PydanticField(ge=10)] = 100
+
+
+class PermutationEntropyResult(BaseModel, frozen=True):
+    """Permutation entropy result for a single embedding dimension.
+
+    Attributes:
+        dimension: Embedding dimension d used for ordinal pattern extraction.
+        normalized_entropy: H_norm in [0, 1]; 1 indicates maximum randomness.
+        js_complexity: Jensen-Shannon statistical complexity C (>= 0).
+    """
+
+    dimension: Annotated[int, PydanticField(ge=2)]
+    normalized_entropy: Annotated[float, PydanticField(ge=0, le=1)]
+    js_complexity: Annotated[float, PydanticField(ge=0)]
+
+
+class PredictabilityProfile(BaseModel, frozen=True):
+    """Per-asset, per-bar-type predictability assessment profile.
+
+    Contains permutation entropy, Kish effective sample size,
+    minimum detectable effect for directional accuracy, break-even DA
+    from transaction costs, and signal-to-noise ratio from Ridge regression.
+
+    Tier gating:
+        - **Tier A/B:** Permutation entropy, Kish N_eff, MDE DA, breakeven DA.
+        - **Tier A only (+ features):** SNR R² via Ridge regression.
+        - **Tier C:** All analysis fields are None.
+
+    Attributes:
+        asset: Trading pair symbol (e.g. ``"BTCUSDT"``).
+        bar_type: Bar aggregation type (e.g. ``"dollar"``).
+        tier: Sample-size tier controlling analysis depth.
+        n_observations: Number of return observations analysed.
+        permutation_entropies: Per-dimension PE results (Tier A/B only).
+        n_eff: Kish effective sample size (Tier A/B only).
+        n_eff_ratio: N_eff / N ratio (Tier A/B only).
+        mde_da: Minimum detectable directional accuracy above 0.5 (Tier A/B only).
+        breakeven_da: Break-even DA from transaction costs (Tier A/B only).
+        snr_r2: Adjusted R-squared from Ridge on real features (Tier A only).
+        snr_r2_noise_baseline: Mean adjusted R-squared from random noise features (Tier A only).
+        is_predictable_vs_noise: Whether snr_r2 exceeds snr_r2_noise_baseline (Tier A only).
+    """
+
+    asset: str
+    bar_type: str
+    tier: SampleTier
+    n_observations: Annotated[int, PydanticField(ge=0)]
+
+    # Permutation entropy (Tier A/B only -- None for Tier C)
+    permutation_entropies: tuple[PermutationEntropyResult, ...] | None = None
+
+    # Kish effective sample size (Tier A/B only -- None for Tier C)
+    n_eff: float | None = None
+    n_eff_ratio: float | None = None
+
+    # Minimum detectable effect (Tier A/B only -- None for Tier C)
+    mde_da: float | None = None
+
+    # Break-even directional accuracy (Tier A/B only -- None for Tier C)
+    breakeven_da: float | None = None
+
+    # Signal-to-noise ratio (Tier A only + features -- None otherwise)
+    snr_r2: float | None = None
+    snr_r2_noise_baseline: float | None = None
+    is_predictable_vs_noise: bool | None = None

--- a/src/tests/profiling/conftest.py
+++ b/src/tests/profiling/conftest.py
@@ -2,7 +2,7 @@
 
 Provides synthetic data generators for stationarity testing,
 distribution analysis, serial dependence analysis, volatility
-modeling, and reusable configuration fixtures.
+modeling, predictability assessment, and reusable configuration fixtures.
 """
 
 from __future__ import annotations
@@ -370,3 +370,78 @@ def make_nonlinear_returns(
         else:
             data[i] = -0.5 * data[i - 1] + noise[i]
     return pd.Series(data, dtype=np.float64, name="tar_return")
+
+
+# ---------------------------------------------------------------------------
+# Predictability assessment helpers
+# ---------------------------------------------------------------------------
+
+
+def make_deterministic_returns(
+    n: int = 2000,
+    seed: int = 42,
+) -> pd.Series:  # type: ignore[type-arg]
+    """Generate highly predictable (low entropy) returns.
+
+    Alternating positive/negative pattern with small noise.
+
+    Args:
+        n: Number of return observations.
+        seed: Random seed for reproducibility.
+
+    Returns:
+        Pandas Series of near-deterministic alternating returns.
+    """
+    rng = np.random.default_rng(seed)
+    pattern = np.array([0.01, -0.01] * (n // 2), dtype=np.float64)
+    noise = rng.normal(0, 0.001, size=n)
+    return pd.Series(pattern + noise[:n], dtype=np.float64, name="deterministic_return")
+
+
+def make_random_walk_predictability_returns(
+    n: int = 2000,
+    seed: int = 42,
+) -> pd.Series:  # type: ignore[type-arg]
+    """Generate random walk returns (high entropy, unpredictable).
+
+    Args:
+        n: Number of return observations.
+        seed: Random seed for reproducibility.
+
+    Returns:
+        Pandas Series of i.i.d. Normal returns simulating random walk increments.
+    """
+    rng = np.random.default_rng(seed)
+    data = rng.normal(loc=0.0, scale=0.01, size=n)
+    return pd.Series(data, dtype=np.float64, name="rw_return")
+
+
+def make_predictable_features(
+    returns: np.ndarray,  # type: ignore[type-arg]
+    n_informative: int = 5,
+    n_noise: int = 10,
+    seed: int = 42,
+) -> np.ndarray:  # type: ignore[type-arg]
+    """Generate a feature matrix with some informative and some noise features.
+
+    Informative features are lagged copies of returns plus noise.
+    Noise features are pure random Gaussian.
+
+    Args:
+        returns: 1-D array of return observations.
+        n_informative: Number of informative (lagged return) features.
+        n_noise: Number of pure noise features.
+        seed: Random seed for reproducibility.
+
+    Returns:
+        Feature matrix of shape ``(n, n_informative + n_noise)``.
+    """
+    rng = np.random.default_rng(seed)
+    n = len(returns)
+    features = np.zeros((n, n_informative + n_noise), dtype=np.float64)
+    for i in range(n_informative):
+        lag = i + 1
+        features[lag:, i] = returns[:-lag] + rng.normal(0, 0.002, size=n - lag)
+    for i in range(n_noise):
+        features[:, n_informative + i] = rng.normal(0, 0.01, size=n)
+    return features

--- a/src/tests/profiling/test_predictability.py
+++ b/src/tests/profiling/test_predictability.py
@@ -1,0 +1,416 @@
+"""Tests for PredictabilityAnalyzer against synthetic deterministic and random data.
+
+Verifies permutation entropy, Kish effective sample size, minimum detectable
+effect, break-even directional accuracy, signal-to-noise ratio, tier gating,
+configuration, and edge cases.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd  # type: ignore[import-untyped]
+import pytest
+
+from src.app.profiling.application.predictability import PredictabilityAnalyzer
+from src.app.profiling.domain.value_objects import (
+    PredictabilityConfig,
+    SampleTier,
+)
+from src.tests.profiling.conftest import (
+    make_deterministic_returns,
+    make_predictable_features,
+    make_random_walk_predictability_returns,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _default_config() -> PredictabilityConfig:
+    """Return a default PredictabilityConfig for tests."""
+    return PredictabilityConfig()
+
+
+def _make_analyzer() -> PredictabilityAnalyzer:
+    """Return a fresh PredictabilityAnalyzer instance."""
+    return PredictabilityAnalyzer()
+
+
+# ---------------------------------------------------------------------------
+# Permutation entropy tests
+# ---------------------------------------------------------------------------
+
+
+class TestPermutationEntropy:
+    """Tests for permutation entropy computation."""
+
+    def test_high_entropy_for_random_walk(self) -> None:
+        """Random walk returns should have H_norm > 0.9 for all dimensions."""
+        returns = make_random_walk_predictability_returns(n=3000, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A)
+
+        assert profile.permutation_entropies is not None
+        for pe_result in profile.permutation_entropies:
+            assert pe_result.normalized_entropy > 0.9, (
+                f"d={pe_result.dimension}: H_norm={pe_result.normalized_entropy:.4f} should be > 0.9"
+            )
+
+    def test_lower_entropy_for_deterministic(self) -> None:
+        """Deterministic pattern returns should have lower H_norm than random walk."""
+        rw_returns = make_random_walk_predictability_returns(n=3000, seed=42)
+        det_returns = make_deterministic_returns(n=3000, seed=42)
+
+        rw_profile = _make_analyzer().analyze(rw_returns, "BTCUSDT", "dollar", SampleTier.A)
+        det_profile = _make_analyzer().analyze(det_returns, "BTCUSDT", "dollar", SampleTier.A)
+
+        assert rw_profile.permutation_entropies is not None
+        assert det_profile.permutation_entropies is not None
+
+        for rw_pe, det_pe in zip(
+            rw_profile.permutation_entropies,
+            det_profile.permutation_entropies,
+            strict=True,
+        ):
+            assert det_pe.normalized_entropy < rw_pe.normalized_entropy, (
+                f"d={det_pe.dimension}: deterministic H_norm={det_pe.normalized_entropy:.4f} "
+                f"should be < random walk H_norm={rw_pe.normalized_entropy:.4f}"
+            )
+
+    def test_dimensions_match_config(self) -> None:
+        """Number of PE results should equal len(config.pe_dimensions)."""
+        config = PredictabilityConfig(pe_dimensions=(3, 5))
+        returns = make_random_walk_predictability_returns(n=2000, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A, config=config)
+
+        assert profile.permutation_entropies is not None
+        assert len(profile.permutation_entropies) == 2
+        assert profile.permutation_entropies[0].dimension == 3
+        assert profile.permutation_entropies[1].dimension == 5
+
+    def test_complexity_positive(self) -> None:
+        """JS complexity C should be >= 0 for all dimensions."""
+        returns = make_random_walk_predictability_returns(n=2000, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A)
+
+        assert profile.permutation_entropies is not None
+        for pe_result in profile.permutation_entropies:
+            assert pe_result.js_complexity >= 0, (
+                f"d={pe_result.dimension}: C={pe_result.js_complexity:.4f} should be >= 0"
+            )
+
+    def test_none_for_tier_c(self) -> None:
+        """Tier C should have no permutation entropy results."""
+        returns = make_random_walk_predictability_returns(n=2000, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.C)
+
+        assert profile.permutation_entropies is None
+
+
+# ---------------------------------------------------------------------------
+# Kish effective sample size tests
+# ---------------------------------------------------------------------------
+
+
+class TestKishNeff:
+    """Tests for Kish effective sample size computation."""
+
+    def test_iid_neff_close_to_n(self) -> None:
+        """i.i.d. returns should have n_eff_ratio close to 1.0."""
+        returns = make_random_walk_predictability_returns(n=2000, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A)
+
+        assert profile.n_eff_ratio is not None
+        assert profile.n_eff_ratio > 0.7, f"n_eff_ratio={profile.n_eff_ratio:.3f} should be > 0.7 for i.i.d. data"
+
+    def test_autocorrelated_neff_lower(self) -> None:
+        """AR(1) returns should have lower n_eff_ratio than i.i.d."""
+        # Create autocorrelated returns: AR(1) with phi=0.5
+        rng = np.random.default_rng(42)
+        n = 2000
+        noise = rng.normal(0, 0.01, size=n)
+        ar1_data = np.zeros(n, dtype=np.float64)
+        for i in range(1, n):
+            ar1_data[i] = 0.5 * ar1_data[i - 1] + noise[i]
+        ar1_returns = pd.Series(ar1_data, dtype=np.float64, name="ar1")
+
+        profile = _make_analyzer().analyze(ar1_returns, "BTCUSDT", "dollar", SampleTier.A)
+
+        assert profile.n_eff_ratio is not None
+        assert profile.n_eff_ratio < 0.8, f"n_eff_ratio={profile.n_eff_ratio:.3f} should be < 0.8 for AR(1) phi=0.5"
+
+    def test_none_for_tier_c(self) -> None:
+        """Tier C should have no n_eff."""
+        returns = make_random_walk_predictability_returns(n=2000, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.C)
+
+        assert profile.n_eff is None
+        assert profile.n_eff_ratio is None
+
+
+# ---------------------------------------------------------------------------
+# MDE directional accuracy tests
+# ---------------------------------------------------------------------------
+
+
+class TestMDE:
+    """Tests for minimum detectable effect for directional accuracy."""
+
+    def test_mde_decreases_with_larger_neff(self) -> None:
+        """Larger effective sample size should yield a smaller MDE (lower mde_da)."""
+        small_returns = make_random_walk_predictability_returns(n=500, seed=42)
+        large_returns = make_random_walk_predictability_returns(n=5000, seed=42)
+
+        small_profile = _make_analyzer().analyze(small_returns, "BTCUSDT", "dollar", SampleTier.B)
+        large_profile = _make_analyzer().analyze(large_returns, "BTCUSDT", "dollar", SampleTier.A)
+
+        assert small_profile.mde_da is not None
+        assert large_profile.mde_da is not None
+        assert large_profile.mde_da < small_profile.mde_da, (
+            f"Large N mde_da={large_profile.mde_da:.4f} should be < small N mde_da={small_profile.mde_da:.4f}"
+        )
+
+    def test_mde_above_50_percent(self) -> None:
+        """MDE DA should always be above 0.5."""
+        returns = make_random_walk_predictability_returns(n=2000, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A)
+
+        assert profile.mde_da is not None
+        assert profile.mde_da > 0.5
+
+    def test_none_for_tier_c(self) -> None:
+        """Tier C should have no MDE DA."""
+        returns = make_random_walk_predictability_returns(n=2000, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.C)
+
+        assert profile.mde_da is None
+
+
+# ---------------------------------------------------------------------------
+# Break-even DA tests
+# ---------------------------------------------------------------------------
+
+
+class TestBreakevenDA:
+    """Tests for break-even directional accuracy from transaction costs."""
+
+    def test_breakeven_da_realistic_range(self) -> None:
+        """For typical crypto returns, breakeven_da should be in [0.5, 0.7]."""
+        returns = make_random_walk_predictability_returns(n=2000, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A)
+
+        assert profile.breakeven_da is not None
+        assert 0.5 <= profile.breakeven_da <= 0.7, f"breakeven_da={profile.breakeven_da:.4f} should be in [0.5, 0.7]"
+
+    def test_zero_returns_gives_max_da(self) -> None:
+        """Near-zero mean absolute return should give breakeven_da = 1.0."""
+        returns = pd.Series(np.zeros(500, dtype=np.float64), name="zero_return")
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.B)
+
+        assert profile.breakeven_da is not None
+        assert profile.breakeven_da == 1.0
+
+    def test_none_for_tier_c(self) -> None:
+        """Tier C should have no breakeven DA."""
+        returns = make_random_walk_predictability_returns(n=2000, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.C)
+
+        assert profile.breakeven_da is None
+
+
+# ---------------------------------------------------------------------------
+# Signal-to-noise ratio tests
+# ---------------------------------------------------------------------------
+
+
+class TestSNR:
+    """Tests for signal-to-noise ratio via Ridge regression."""
+
+    def test_snr_with_informative_features(self) -> None:
+        """Predictable features should yield snr_r2 > snr_r2_noise_baseline."""
+        returns = make_deterministic_returns(n=3000, seed=42)
+        returns_arr = returns.to_numpy(dtype=np.float64)
+        features = make_predictable_features(returns_arr, n_informative=5, n_noise=5, seed=42)
+
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A, features=features)
+
+        assert profile.snr_r2 is not None
+        assert profile.snr_r2_noise_baseline is not None
+        assert profile.is_predictable_vs_noise is True
+
+    def test_snr_noise_only_features(self) -> None:
+        """Random features on random returns should yield snr_r2 near or below noise baseline."""
+        returns = make_random_walk_predictability_returns(n=3000, seed=42)
+        rng = np.random.default_rng(99)
+        noise_features = rng.normal(0, 0.01, size=(3000, 15))
+
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A, features=noise_features)
+
+        assert profile.snr_r2 is not None
+        assert profile.snr_r2_noise_baseline is not None
+        # With only noise features, R² should be close to noise baseline
+        # Allow small margin because of randomness
+        assert profile.snr_r2 < profile.snr_r2_noise_baseline + 0.05
+
+    def test_snr_none_without_features(self) -> None:
+        """Without features, SNR fields should be None."""
+        returns = make_random_walk_predictability_returns(n=3000, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A)
+
+        assert profile.snr_r2 is None
+        assert profile.snr_r2_noise_baseline is None
+        assert profile.is_predictable_vs_noise is None
+
+    def test_snr_tier_a_only(self) -> None:
+        """Tier B should have no SNR fields even with features."""
+        returns = make_random_walk_predictability_returns(n=2000, seed=42)
+        rng = np.random.default_rng(42)
+        features = rng.normal(0, 0.01, size=(2000, 10))
+
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.B, features=features)
+
+        assert profile.snr_r2 is None
+        assert profile.snr_r2_noise_baseline is None
+        assert profile.is_predictable_vs_noise is None
+
+
+# ---------------------------------------------------------------------------
+# Tier gating tests
+# ---------------------------------------------------------------------------
+
+
+class TestTierGating:
+    """Tests for correct tier-based gating of analysis components."""
+
+    def test_tier_a_full(self) -> None:
+        """Tier A with features should populate all fields."""
+        returns = make_random_walk_predictability_returns(n=3000, seed=42)
+        returns_arr = returns.to_numpy(dtype=np.float64)
+        features = make_predictable_features(returns_arr, n_informative=3, n_noise=5, seed=42)
+
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A, features=features)
+
+        assert profile.permutation_entropies is not None
+        assert profile.n_eff is not None
+        assert profile.n_eff_ratio is not None
+        assert profile.mde_da is not None
+        assert profile.breakeven_da is not None
+        assert profile.snr_r2 is not None
+        assert profile.snr_r2_noise_baseline is not None
+        assert profile.is_predictable_vs_noise is not None
+
+    def test_tier_b_no_snr(self) -> None:
+        """Tier B should have PE/N_eff/MDE but no SNR."""
+        returns = make_random_walk_predictability_returns(n=2000, seed=42)
+        rng = np.random.default_rng(42)
+        features = rng.normal(0, 0.01, size=(2000, 10))
+
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.B, features=features)
+
+        # Populated for Tier B
+        assert profile.permutation_entropies is not None
+        assert profile.n_eff is not None
+        assert profile.mde_da is not None
+        assert profile.breakeven_da is not None
+
+        # Not populated for Tier B
+        assert profile.snr_r2 is None
+        assert profile.snr_r2_noise_baseline is None
+        assert profile.is_predictable_vs_noise is None
+
+    def test_tier_c_minimal(self) -> None:
+        """Tier C should have all analysis fields as None."""
+        returns = make_random_walk_predictability_returns(n=2000, seed=42)
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.C)
+
+        assert profile.permutation_entropies is None
+        assert profile.n_eff is None
+        assert profile.n_eff_ratio is None
+        assert profile.mde_da is None
+        assert profile.breakeven_da is None
+        assert profile.snr_r2 is None
+        assert profile.snr_r2_noise_baseline is None
+        assert profile.is_predictable_vs_noise is None
+
+
+# ---------------------------------------------------------------------------
+# Configuration tests
+# ---------------------------------------------------------------------------
+
+
+class TestPredictabilityConfig:
+    """Tests for PredictabilityConfig defaults and immutability."""
+
+    def test_defaults(self) -> None:
+        """Verify default config values match specification."""
+        config = PredictabilityConfig()
+
+        assert config.pe_dimensions == (3, 4, 5, 6)
+        assert config.pe_delay == 1
+        assert config.alpha == 0.05
+        assert config.power == 0.80
+        assert config.round_trip_cost == 0.002
+        assert config.snr_holdout_fraction == 0.30
+        assert config.snr_ridge_alpha == 1.0
+        assert config.snr_n_noise_baselines == 10
+        assert config.bartlett_max_lag_fraction == 0.1
+        assert config.min_samples_predictability == 100
+
+    def test_immutability(self) -> None:
+        """Frozen config should reject attribute assignment."""
+        config = PredictabilityConfig()
+        with pytest.raises(Exception):  # noqa: B017, PT011
+            config.alpha = 0.01  # type: ignore[misc]
+
+    def test_custom_config(self) -> None:
+        """Custom configuration values should be accepted."""
+        config = PredictabilityConfig(
+            pe_dimensions=(3, 5, 7),
+            pe_delay=2,
+            alpha=0.10,
+            power=0.90,
+            round_trip_cost=0.003,
+            snr_holdout_fraction=0.20,
+            snr_ridge_alpha=0.5,
+            snr_n_noise_baselines=5,
+            bartlett_max_lag_fraction=0.05,
+            min_samples_predictability=50,
+        )
+
+        assert config.pe_dimensions == (3, 5, 7)
+        assert config.pe_delay == 2
+        assert config.alpha == 0.10
+        assert config.power == 0.90
+
+
+# ---------------------------------------------------------------------------
+# Edge case tests
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Tests for edge cases and degenerate inputs."""
+
+    def test_short_series(self) -> None:
+        """Series shorter than min_samples should return all None."""
+        returns = pd.Series(np.random.default_rng(42).normal(0, 0.01, size=50), name="short")
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.A)
+
+        assert profile.n_observations == 50
+        assert profile.permutation_entropies is None
+        assert profile.n_eff is None
+        assert profile.mde_da is None
+        assert profile.breakeven_da is None
+        assert profile.snr_r2 is None
+
+    def test_constant_returns(self) -> None:
+        """Constant returns should not raise errors."""
+        returns = pd.Series(np.full(500, 0.001, dtype=np.float64), name="constant")
+        profile = _make_analyzer().analyze(returns, "BTCUSDT", "dollar", SampleTier.B)
+
+        # Should complete without raising
+        assert profile.n_observations == 500
+        assert profile.permutation_entropies is not None
+        assert profile.n_eff is not None
+        assert profile.breakeven_da is not None


### PR DESCRIPTION
## Summary
- **Permutation entropy** (Bandt & Pompe, 2002) across embedding dimensions d={3,4,5,6} with Jensen-Shannon complexity for positioning on the complexity-entropy plane — directly confronts R5 (crypto ≈ Brownian noise)
- **Kish effective sample size** with Bartlett bandwidth truncation for autocorrelation-adjusted N_eff
- **Minimum detectable effect** for directional accuracy via normal approximation to binomial (α=0.05, power=0.80)
- **Break-even DA** from transaction costs (round_trip_cost=0.002 for Binance spot)
- **Signal-to-noise R²** via Ridge regression on temporal holdout vs. random Gaussian noise baseline
- All analysis tier-gated: PE/N_eff/MDE/breakeven for Tier A/B, SNR for Tier A only
- 3 new value objects, 1 new service (`PredictabilityAnalyzer`), 3 test factories, **26 tests** across 8 classes

Closes #57

## Test plan
- [x] `just test src/tests/profiling/test_predictability.py` — 26/26 pass
- [x] `just test src/tests/profiling/` — 155/155 pass (no regressions)
- [x] `just lint` — ruff format, ruff lint, pyright all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)