### PR TITLE
feat(profiling): add Phase 5E profiling service, config & BH FDR correction

### DIFF
--- a/src/app/profiling/application/services.py
+++ b/src/app/profiling/application/services.py
@@ -1,0 +1,655 @@
+"""Orchestrator service for statistical profiling across all asset-bar combinations."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd  # type: ignore[import-untyped]
+from loguru import logger
+from statsmodels.stats.multitest import multipletests  # type: ignore[import-untyped]
+
+from src.app.profiling.application.distribution import DistributionAnalyzer
+from src.app.profiling.application.predictability import PredictabilityAnalyzer
+from src.app.profiling.application.serial_dependence import SerialDependenceAnalyzer
+from src.app.profiling.application.stationarity import StationarityScreener
+from src.app.profiling.application.volatility import VolatilityAnalyzer
+from src.app.profiling.domain.value_objects import (
+    AssetBarProfile,
+    AutocorrelationProfile,
+    CorrectedPValue,
+    DataPartition,
+    DistributionProfile,
+    PredictabilityProfile,
+    ProfilingConfig,
+    SampleTier,
+    StationarityReport,
+    StatisticalReport,
+    TierClassifier,
+    VolatilityProfile,
+)
+from src.app.research.application.data_loader import DataLoader
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_SECONDS_PER_DAY: float = 86400.0
+"""Number of seconds in a calendar day."""
+
+_DEFAULT_SIGNIFICANCE_ALPHA: float = 0.05
+"""Default significance level used when the sub-profile does not carry its own alpha."""
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_inferential_pvalues(profile: AssetBarProfile) -> list[CorrectedPValue]:
+    """Extract all inferential test p-values from a single asset-bar profile.
+
+    Scans autocorrelation (Ljung-Box, variance ratio, Granger) and
+    volatility (BDS, ARCH-LM, sign bias joint F-test) sub-profiles
+    for raw p-values.  Non-applicable fields (``None``) are skipped.
+
+    Args:
+        profile: A frozen ``AssetBarProfile`` containing sub-profile results.
+
+    Returns:
+        List of ``CorrectedPValue`` objects with ``raw_pvalue`` set and
+        ``corrected_pvalue`` initialised to ``raw_pvalue`` (to be updated
+        by BH correction).
+    """
+    results: list[CorrectedPValue] = []
+    asset: str = profile.asset
+    bar_type: str = profile.bar_type
+
+    # --- Autocorrelation sub-profile ---
+    acf_profile: AutocorrelationProfile | None = profile.autocorrelation
+    if acf_profile is not None:
+        # Ljung-Box on raw returns
+        results.extend(
+            CorrectedPValue(
+                asset=asset,
+                bar_type=bar_type,
+                test_name="ljung_box_returns",
+                parameter=f"lag={lb.lag}",
+                raw_pvalue=lb.p_value,
+                corrected_pvalue=lb.p_value,
+                significant_raw=lb.significant,
+                significant_corrected=lb.significant,
+            )
+            for lb in acf_profile.ljung_box_returns
+        )
+
+        # Ljung-Box on squared returns
+        results.extend(
+            CorrectedPValue(
+                asset=asset,
+                bar_type=bar_type,
+                test_name="ljung_box_squared",
+                parameter=f"lag={lb.lag}",
+                raw_pvalue=lb.p_value,
+                corrected_pvalue=lb.p_value,
+                significant_raw=lb.significant,
+                significant_corrected=lb.significant,
+            )
+            for lb in acf_profile.ljung_box_squared
+        )
+
+        # Variance ratio tests
+        if acf_profile.vr_results is not None:
+            results.extend(
+                CorrectedPValue(
+                    asset=asset,
+                    bar_type=bar_type,
+                    test_name="variance_ratio",
+                    parameter=f"horizon={vr.calendar_horizon_days}d",
+                    raw_pvalue=vr.p_value,
+                    corrected_pvalue=vr.p_value,
+                    significant_raw=vr.significant,
+                    significant_corrected=vr.significant,
+                )
+                for vr in acf_profile.vr_results
+            )
+
+        # Granger causality tests
+        if acf_profile.granger_results is not None:
+            results.extend(
+                CorrectedPValue(
+                    asset=asset,
+                    bar_type=bar_type,
+                    test_name="granger",
+                    parameter=f"{gr.source_name}->{gr.target_name},lag={gr.lag}",
+                    raw_pvalue=gr.p_value,
+                    corrected_pvalue=gr.p_value,
+                    significant_raw=gr.significant,
+                    significant_corrected=gr.significant,
+                )
+                for gr in acf_profile.granger_results
+            )
+
+    # --- Volatility sub-profile ---
+    vol_profile: VolatilityProfile | None = profile.volatility
+    if vol_profile is not None:
+        # BDS test results
+        if vol_profile.bds_results is not None:
+            results.extend(
+                CorrectedPValue(
+                    asset=asset,
+                    bar_type=bar_type,
+                    test_name="bds",
+                    parameter=f"dim={bds_r.dimension}",
+                    raw_pvalue=bds_r.p_value,
+                    corrected_pvalue=bds_r.p_value,
+                    significant_raw=bds_r.significant,
+                    significant_corrected=bds_r.significant,
+                )
+                for bds_r in vol_profile.bds_results
+            )
+
+        # ARCH-LM test
+        if vol_profile.arch_lm_pvalue is not None:
+            arch_pval: float = vol_profile.arch_lm_pvalue
+            results.append(
+                CorrectedPValue(
+                    asset=asset,
+                    bar_type=bar_type,
+                    test_name="arch_lm",
+                    parameter="residuals",
+                    raw_pvalue=arch_pval,
+                    corrected_pvalue=arch_pval,
+                    significant_raw=arch_pval < _DEFAULT_SIGNIFICANCE_ALPHA,
+                    significant_corrected=arch_pval < _DEFAULT_SIGNIFICANCE_ALPHA,
+                )
+            )
+
+        # Sign bias joint F-test
+        if vol_profile.sign_bias is not None:
+            joint_pval: float = vol_profile.sign_bias.joint_f_pvalue
+            results.append(
+                CorrectedPValue(
+                    asset=asset,
+                    bar_type=bar_type,
+                    test_name="sign_bias_joint",
+                    parameter="joint_f",
+                    raw_pvalue=joint_pval,
+                    corrected_pvalue=joint_pval,
+                    significant_raw=joint_pval < _DEFAULT_SIGNIFICANCE_ALPHA,
+                    significant_corrected=joint_pval < _DEFAULT_SIGNIFICANCE_ALPHA,
+                )
+            )
+
+    return results
+
+
+def _apply_bh_correction(
+    raw_pvalues: list[CorrectedPValue],
+    alpha: float,
+) -> tuple[CorrectedPValue, ...]:
+    """Apply Benjamini-Hochberg FDR correction to a collection of p-values.
+
+    Uses ``statsmodels.stats.multitest.multipletests`` with ``method='fdr_bh'``
+    for correctness.  When the input list is empty, returns an empty tuple.
+
+    Args:
+        raw_pvalues: List of ``CorrectedPValue`` objects with ``raw_pvalue``
+            already set.
+        alpha: Family-wise significance level for the FDR procedure.
+
+    Returns:
+        Tuple of new ``CorrectedPValue`` objects with ``corrected_pvalue``
+        and ``significant_corrected`` updated.
+    """
+    if not raw_pvalues:
+        return ()
+
+    pvals: np.ndarray = np.array(  # type: ignore[type-arg]
+        [p.raw_pvalue for p in raw_pvalues],
+        dtype=np.float64,
+    )
+
+    reject: np.ndarray  # type: ignore[type-arg]
+    corrected: np.ndarray  # type: ignore[type-arg]
+    reject, corrected, _, _ = multipletests(pvals, alpha=alpha, method="fdr_bh")  # type: ignore[no-untyped-call]
+
+    corrected_results: list[CorrectedPValue] = []
+    for i, orig in enumerate(raw_pvalues):
+        corrected_pval: float = float(corrected[i])
+        is_significant: bool = bool(reject[i])
+        corrected_results.append(
+            CorrectedPValue(
+                asset=orig.asset,
+                bar_type=orig.bar_type,
+                test_name=orig.test_name,
+                parameter=orig.parameter,
+                raw_pvalue=orig.raw_pvalue,
+                corrected_pvalue=corrected_pval,
+                significant_raw=orig.significant_raw,
+                significant_corrected=is_significant,
+            )
+        )
+
+    return tuple(corrected_results)
+
+
+def _compute_bars_per_day(df: pd.DataFrame, ts_col: str) -> float:
+    """Compute the average number of bars per calendar day from timestamps.
+
+    Args:
+        df: DataFrame containing at least one timestamp column.
+        ts_col: Name of the timestamp column.
+
+    Returns:
+        Bars per day (>= 1.0).  Returns 1.0 for single-row DataFrames.
+    """
+    n: int = len(df)
+    if n <= 1:
+        return 1.0
+
+    first_ts: pd.Timestamp = pd.Timestamp(df[ts_col].iloc[0])  # type: ignore[arg-type]
+    last_ts: pd.Timestamp = pd.Timestamp(df[ts_col].iloc[-1])  # type: ignore[arg-type]
+    total_seconds: float = (last_ts - first_ts).total_seconds()
+
+    if total_seconds <= 0:
+        return 1.0
+
+    total_days: float = total_seconds / _SECONDS_PER_DAY
+    bars_per_day: float = float(n) / total_days
+    return max(1.0, bars_per_day)
+
+
+# ---------------------------------------------------------------------------
+# Public service class
+# ---------------------------------------------------------------------------
+
+
+class ProfilingService:
+    """Orchestrates Phase 5 statistical profiling across all asset-bar combinations.
+
+    Iterates over every (asset, bar_type) pair available in the database,
+    classifies each into a sample-size tier, dispatches to the appropriate
+    Phase 5 analyzers, and aggregates the results into a ``StatisticalReport``
+    with Benjamini-Hochberg FDR-corrected p-values.
+
+    The ``DataLoader`` dependency is duck-typed: any object implementing the
+    same public API (``load_ohlcv``, ``load_bars``, ``get_available_assets``,
+    ``get_available_bar_configs``) can be injected for testing.
+    """
+
+    def __init__(self, data_loader: DataLoader) -> None:
+        """Initialise the service with a data loader dependency.
+
+        Args:
+            data_loader: DataLoader (or duck-typed equivalent) for reading
+                OHLCV and aggregated bar data from the database.
+        """
+        self._data_loader: DataLoader = data_loader
+        self._tier_classifier: TierClassifier = TierClassifier()
+        self._distribution_analyzer: DistributionAnalyzer = DistributionAnalyzer()
+        self._serial_analyzer: SerialDependenceAnalyzer = SerialDependenceAnalyzer()
+        self._volatility_analyzer: VolatilityAnalyzer = VolatilityAnalyzer()
+        self._predictability_analyzer: PredictabilityAnalyzer = PredictabilityAnalyzer()
+        self._stationarity_screener: StationarityScreener = StationarityScreener()
+
+    def profile_all(  # noqa: PLR0912, PLR0914
+        self,
+        assets: list[str] | None = None,
+        config: ProfilingConfig | None = None,
+        partition: DataPartition | None = None,
+    ) -> StatisticalReport:
+        """Profile all asset-bar combinations and return an FDR-corrected report.
+
+        For each asset, loads all available bar types plus time_1h (from OHLCV),
+        computes log returns, and dispatches to each Phase 5 analyzer.
+        Inferential p-values are extracted from all profiles and corrected
+        via Benjamini-Hochberg FDR.
+
+        Args:
+            assets: Asset symbols to profile.  When ``None``, queries the
+                database for all available assets.
+            config: Composite profiling configuration.  Uses defaults when ``None``.
+            partition: Temporal partition for filtering data.  Uses
+                ``DataPartition.default()`` when ``None``.
+
+        Returns:
+            Frozen ``StatisticalReport`` with all profiles and corrected p-values.
+        """
+        if config is None:
+            config = ProfilingConfig()
+        if partition is None:
+            partition = DataPartition.default()
+
+        if assets is None:
+            assets = self._data_loader.get_available_assets()
+
+        logger.info("Starting full profiling for {} asset(s)", len(assets))
+
+        all_profiles: list[AssetBarProfile] = []
+
+        for asset in assets:
+            # Aggregated bar types
+            bar_configs: list[tuple[str, str]] = self._data_loader.get_available_bar_configs(asset)
+            for bar_type, config_hash in bar_configs:
+                profile: AssetBarProfile = self.profile_single(
+                    asset=asset,
+                    bar_type=bar_type,
+                    config_hash=config_hash,
+                    config=config,
+                    partition=partition,
+                )
+                all_profiles.append(profile)
+
+            # Time bars (time_1h) from OHLCV
+            profile_time: AssetBarProfile = self.profile_single(
+                asset=asset,
+                bar_type="time_1h",
+                config_hash=None,
+                config=config,
+                partition=partition,
+            )
+            all_profiles.append(profile_time)
+
+        # Extract all inferential p-values across all profiles
+        all_raw_pvalues: list[CorrectedPValue] = []
+        for prof in all_profiles:
+            all_raw_pvalues.extend(_extract_inferential_pvalues(prof))
+
+        # Apply Benjamini-Hochberg FDR correction
+        corrected_pvalues: tuple[CorrectedPValue, ...] = _apply_bh_correction(all_raw_pvalues, config.fdr_alpha)
+
+        # Compute summary statistics
+        n_assets: int = len({p.asset for p in all_profiles})
+        n_bar_types: int = len({p.bar_type for p in all_profiles})
+        n_total_tests: int = len(corrected_pvalues)
+        n_significant_raw: int = sum(1 for p in corrected_pvalues if p.significant_raw)
+        n_significant_corrected: int = sum(1 for p in corrected_pvalues if p.significant_corrected)
+
+        logger.info(
+            "Profiling complete: {} profiles, {} tests, {} sig raw, {} sig corrected",
+            len(all_profiles),
+            n_total_tests,
+            n_significant_raw,
+            n_significant_corrected,
+        )
+
+        return StatisticalReport(
+            profiles=tuple(all_profiles),
+            corrected_pvalues=corrected_pvalues,
+            n_assets=n_assets,
+            n_bar_types=n_bar_types,
+            n_total_tests=n_total_tests,
+            n_significant_raw=n_significant_raw,
+            n_significant_corrected=n_significant_corrected,
+        )
+
+    def profile_single(  # noqa: PLR0913, PLR0917, PLR0914
+        self,
+        asset: str,
+        bar_type: str,
+        config_hash: str | None = None,
+        config: ProfilingConfig | None = None,
+        partition: DataPartition | None = None,
+        feature_columns: list[str] | None = None,
+    ) -> AssetBarProfile:
+        """Profile a single (asset, bar_type) combination.
+
+        Loads bar or OHLCV data, computes log returns, classifies the
+        sample tier, and runs all applicable Phase 5 analyzers.
+
+        Args:
+            asset: Trading pair symbol (e.g. ``"BTCUSDT"``).
+            bar_type: Bar aggregation type (e.g. ``"dollar"``, ``"time_1h"``).
+            config_hash: Bar configuration hash (required for non-time bars).
+                ``None`` for time bars which are loaded from OHLCV.
+            config: Composite profiling configuration.  Uses defaults when ``None``.
+            partition: Temporal partition for filtering data.  Uses
+                ``DataPartition.default()`` when ``None``.
+            feature_columns: Optional list of feature column names to run
+                stationarity screening on.  When ``None``, stationarity is skipped.
+
+        Returns:
+            Frozen ``AssetBarProfile`` value object.
+        """
+        if config is None:
+            config = ProfilingConfig()
+        if partition is None:
+            partition = DataPartition.default()
+
+        # Load data
+        df: pd.DataFrame = self._load_data(asset, bar_type, config_hash, partition)
+
+        if df.empty:
+            logger.warning("No data for asset={}, bar_type={}, returning empty profile", asset, bar_type)
+            return AssetBarProfile(
+                asset=asset,
+                bar_type=bar_type,
+                tier=SampleTier.C,
+                n_observations=0,
+            )
+
+        # Determine timestamp column
+        ts_col: str = "timestamp" if "timestamp" in df.columns else "start_ts"
+
+        # Compute log returns
+        returns: pd.Series = np.log(df["close"] / df["close"].shift(1)).dropna()  # type: ignore[type-arg]
+
+        n_returns: int = len(returns)
+        tier: SampleTier = self._tier_classifier.classify(n_returns, config.tier)
+
+        logger.debug(
+            "Profiling asset={}, bar_type={}, n_returns={}, tier={}",
+            asset,
+            bar_type,
+            n_returns,
+            tier.value,
+        )
+
+        if n_returns == 0:
+            return AssetBarProfile(
+                asset=asset,
+                bar_type=bar_type,
+                tier=tier,
+                n_observations=0,
+            )
+
+        # Compute bars_per_day for serial dependence
+        bars_per_day: float = _compute_bars_per_day(df, ts_col)
+
+        # Run all analyzers
+        distribution: DistributionProfile | None = self._run_distribution(returns, asset, bar_type, tier, config)
+        autocorrelation: AutocorrelationProfile | None = self._run_serial_dependence(
+            returns, asset, bar_type, tier, bars_per_day, config
+        )
+        volatility: VolatilityProfile | None = self._run_volatility(returns, asset, bar_type, tier, config)
+        predictability: PredictabilityProfile | None = self._run_predictability(returns, asset, bar_type, tier, config)
+        stationarity: StationarityReport | None = self._run_stationarity(df, asset, bar_type, feature_columns, config)
+
+        return AssetBarProfile(
+            asset=asset,
+            bar_type=bar_type,
+            tier=tier,
+            n_observations=n_returns,
+            distribution=distribution,
+            autocorrelation=autocorrelation,
+            volatility=volatility,
+            predictability=predictability,
+            stationarity=stationarity,
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _load_data(
+        self,
+        asset: str,
+        bar_type: str,
+        config_hash: str | None,
+        partition: DataPartition,
+    ) -> pd.DataFrame:
+        """Load and temporally filter bar or OHLCV data.
+
+        Args:
+            asset: Trading pair symbol.
+            bar_type: Bar aggregation type.
+            config_hash: Bar configuration hash (``None`` for time bars).
+            partition: Temporal partition for date filtering.
+
+        Returns:
+            Filtered Pandas DataFrame ordered by timestamp.
+        """
+        date_range: tuple[pd.Timestamp, pd.Timestamp] = (  # type: ignore[assignment]
+            partition.feature_selection_start,
+            partition.feature_selection_end,
+        )
+
+        if bar_type == "time_1h":
+            df: pd.DataFrame = self._data_loader.load_ohlcv(asset, "1h", date_range=date_range)  # type: ignore[arg-type]
+        else:
+            if config_hash is None:
+                logger.warning("config_hash is None for non-time bar_type={}, returning empty", bar_type)
+                return pd.DataFrame()
+            df = self._data_loader.load_bars(asset, bar_type, config_hash, date_range=date_range)  # type: ignore[arg-type]
+
+        return df
+
+    def _run_distribution(  # noqa: PLR6301
+        self,
+        returns: pd.Series,  # type: ignore[type-arg]
+        asset: str,
+        bar_type: str,
+        tier: SampleTier,
+        config: ProfilingConfig,
+    ) -> DistributionProfile | None:
+        """Run distribution analysis, catching unexpected exceptions.
+
+        Args:
+            returns: Log return series.
+            asset: Trading pair symbol.
+            bar_type: Bar aggregation type.
+            tier: Sample tier.
+            config: Composite profiling configuration.
+
+        Returns:
+            Distribution profile, or ``None`` on failure.
+        """
+        try:
+            return self._distribution_analyzer.analyze(returns, asset, bar_type, tier, config.distribution)
+        except Exception:
+            logger.exception("Distribution analysis failed for asset={}, bar_type={}", asset, bar_type)
+            return None
+
+    def _run_serial_dependence(  # noqa: PLR6301, PLR0913, PLR0917
+        self,
+        returns: pd.Series,  # type: ignore[type-arg]
+        asset: str,
+        bar_type: str,
+        tier: SampleTier,
+        bars_per_day: float,
+        config: ProfilingConfig,
+    ) -> AutocorrelationProfile | None:
+        """Run serial dependence analysis, catching unexpected exceptions.
+
+        Args:
+            returns: Log return series.
+            asset: Trading pair symbol.
+            bar_type: Bar aggregation type.
+            tier: Sample tier.
+            bars_per_day: Average bars per calendar day.
+            config: Composite profiling configuration.
+
+        Returns:
+            Autocorrelation profile, or ``None`` on failure.
+        """
+        try:
+            return self._serial_analyzer.analyze(returns, asset, bar_type, tier, bars_per_day, config.autocorrelation)
+        except Exception:
+            logger.exception("Serial dependence analysis failed for asset={}, bar_type={}", asset, bar_type)
+            return None
+
+    def _run_volatility(  # noqa: PLR6301
+        self,
+        returns: pd.Series,  # type: ignore[type-arg]
+        asset: str,
+        bar_type: str,
+        tier: SampleTier,
+        config: ProfilingConfig,
+    ) -> VolatilityProfile | None:
+        """Run volatility analysis, catching unexpected exceptions.
+
+        Args:
+            returns: Log return series.
+            asset: Trading pair symbol.
+            bar_type: Bar aggregation type.
+            tier: Sample tier.
+            config: Composite profiling configuration.
+
+        Returns:
+            Volatility profile, or ``None`` on failure.
+        """
+        try:
+            return self._volatility_analyzer.analyze(returns, asset, bar_type, tier, config.volatility)
+        except Exception:
+            logger.exception("Volatility analysis failed for asset={}, bar_type={}", asset, bar_type)
+            return None
+
+    def _run_predictability(  # noqa: PLR6301
+        self,
+        returns: pd.Series,  # type: ignore[type-arg]
+        asset: str,
+        bar_type: str,
+        tier: SampleTier,
+        config: ProfilingConfig,
+    ) -> PredictabilityProfile | None:
+        """Run predictability assessment, catching unexpected exceptions.
+
+        Args:
+            returns: Log return series.
+            asset: Trading pair symbol.
+            bar_type: Bar aggregation type.
+            tier: Sample tier.
+            config: Composite profiling configuration.
+
+        Returns:
+            Predictability profile, or ``None`` on failure.
+        """
+        try:
+            return self._predictability_analyzer.analyze(returns, asset, bar_type, tier, config.predictability)
+        except Exception:
+            logger.exception("Predictability analysis failed for asset={}, bar_type={}", asset, bar_type)
+            return None
+
+    def _run_stationarity(  # noqa: PLR6301, PLR0913, PLR0917
+        self,
+        df: pd.DataFrame,
+        asset: str,
+        bar_type: str,
+        feature_columns: list[str] | None,
+        config: ProfilingConfig,
+    ) -> StationarityReport | None:
+        """Run stationarity screening on feature columns if available.
+
+        Args:
+            df: Full DataFrame (may include feature columns).
+            asset: Trading pair symbol.
+            bar_type: Bar aggregation type.
+            feature_columns: Feature column names to screen.  When ``None``,
+                stationarity screening is skipped entirely.
+            config: Composite profiling configuration.
+
+        Returns:
+            Stationarity report, or ``None`` when no features or on failure.
+        """
+        if feature_columns is None:
+            return None
+
+        # Filter to feature columns that actually exist in the DataFrame
+        available: list[str] = [c for c in feature_columns if c in df.columns]
+        if not available:
+            return None
+
+        try:
+            return self._stationarity_screener.screen(df, available, asset, bar_type, config.stationarity_alpha)
+        except Exception:
+            logger.exception("Stationarity screening failed for asset={}, bar_type={}", asset, bar_type)
+            return None

--- a/src/app/profiling/domain/value_objects.py
+++ b/src/app/profiling/domain/value_objects.py
@@ -1,4 +1,4 @@
-"""Profiling domain value objects -- data partitions, sample tiers, distribution profiles, and stationarity results."""
+"""Profiling domain value objects -- partitions, tiers, profiles, configs, and statistical report."""
 
 from __future__ import annotations
 
@@ -797,3 +797,118 @@ class PredictabilityProfile(BaseModel, frozen=True):
     snr_r2: float | None = None
     snr_r2_noise_baseline: float | None = None
     is_predictable_vs_noise: bool | None = None
+
+
+# ---------------------------------------------------------------------------
+# Phase 5E: Profiling service value objects
+# ---------------------------------------------------------------------------
+
+
+class ProfilingConfig(BaseModel, frozen=True):
+    """Composite configuration for the full statistical profiling pipeline.
+
+    Holds sub-configs for each Phase 5 analyzer, sample-tier thresholds,
+    FDR correction parameters, and stationarity test settings.
+
+    Attributes:
+        distribution: Distribution analysis sub-config.
+        autocorrelation: Serial dependence sub-config.
+        volatility: Volatility modeling sub-config.
+        predictability: Predictability assessment sub-config.
+        tier: Sample-size tier thresholds.
+        fdr_alpha: Significance level for Benjamini-Hochberg FDR correction.
+        stationarity_alpha: Significance level for ADF/KPSS stationarity tests.
+    """
+
+    distribution: DistributionConfig = DistributionConfig()
+    autocorrelation: AutocorrelationConfig = AutocorrelationConfig()
+    volatility: VolatilityConfig = VolatilityConfig()
+    predictability: PredictabilityConfig = PredictabilityConfig()
+    tier: TierConfig = TierConfig(tier_a_threshold=2000, tier_b_threshold=500)
+    fdr_alpha: Annotated[float, PydanticField(gt=0, lt=1)] = 0.05
+    stationarity_alpha: Annotated[float, PydanticField(gt=0, lt=1)] = 0.05
+
+
+class CorrectedPValue(BaseModel, frozen=True):
+    """A single inferential test p-value with Benjamini-Hochberg FDR correction.
+
+    Stores both raw and corrected p-values along with significance decisions,
+    enabling transparent comparison of pre- and post-correction conclusions.
+
+    Attributes:
+        asset: Trading pair symbol (e.g. ``"BTCUSDT"``).
+        bar_type: Bar aggregation type (e.g. ``"dollar"``).
+        test_name: Identifier for the statistical test (e.g. ``"ljung_box_returns"``).
+        parameter: Test-specific parameter string (e.g. ``"lag=5"``).
+        raw_pvalue: Original (uncorrected) p-value from the test.
+        corrected_pvalue: Benjamini-Hochberg adjusted p-value.
+        significant_raw: Whether the raw p-value is below the FDR alpha.
+        significant_corrected: Whether the corrected p-value is below the FDR alpha.
+    """
+
+    asset: str
+    bar_type: str
+    test_name: str
+    parameter: str
+    raw_pvalue: Annotated[float, PydanticField(ge=0, le=1)]
+    corrected_pvalue: Annotated[float, PydanticField(ge=0, le=1)]
+    significant_raw: bool
+    significant_corrected: bool
+
+
+class AssetBarProfile(BaseModel, frozen=True):
+    """Aggregate statistical profile for a single (asset, bar_type) combination.
+
+    Collects outputs from all Phase 5 analyzers into a single frozen value
+    object.  Fields are ``None`` when the corresponding analyzer was not run
+    (e.g. due to insufficient data or tier gating).
+
+    Attributes:
+        asset: Trading pair symbol (e.g. ``"BTCUSDT"``).
+        bar_type: Bar aggregation type (e.g. ``"dollar"``).
+        tier: Sample-size tier assigned to this combination.
+        n_observations: Number of return observations available.
+        distribution: Return distribution profile (Phase 5A).
+        autocorrelation: Serial dependence profile (Phase 5B).
+        volatility: Volatility modeling profile (Phase 5C).
+        predictability: Predictability assessment profile (Phase 5D).
+        stationarity: Feature stationarity report (Phase 5pre).
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    asset: str
+    bar_type: str
+    tier: SampleTier
+    n_observations: Annotated[int, PydanticField(ge=0)]
+    distribution: DistributionProfile | None = None
+    autocorrelation: AutocorrelationProfile | None = None
+    volatility: VolatilityProfile | None = None
+    predictability: PredictabilityProfile | None = None
+    stationarity: StationarityReport | None = None
+
+
+class StatisticalReport(BaseModel, frozen=True):
+    """Cross-asset statistical profiling report with FDR-corrected p-values.
+
+    Aggregates all per-asset-bar-type profiles and provides summary
+    statistics on hypothesis test outcomes before and after
+    Benjamini-Hochberg correction.
+
+    Attributes:
+        profiles: All per-asset-bar-type statistical profiles.
+        corrected_pvalues: BH-corrected p-values across the full test grid.
+        n_assets: Number of distinct assets profiled.
+        n_bar_types: Number of distinct bar types profiled.
+        n_total_tests: Total number of inferential tests conducted.
+        n_significant_raw: Tests significant before FDR correction.
+        n_significant_corrected: Tests significant after FDR correction.
+    """
+
+    profiles: tuple[AssetBarProfile, ...]
+    corrected_pvalues: tuple[CorrectedPValue, ...]
+    n_assets: Annotated[int, PydanticField(ge=0)]
+    n_bar_types: Annotated[int, PydanticField(ge=0)]
+    n_total_tests: Annotated[int, PydanticField(ge=0)]
+    n_significant_raw: Annotated[int, PydanticField(ge=0)]
+    n_significant_corrected: Annotated[int, PydanticField(ge=0)]

--- a/src/tests/profiling/test_services.py
+++ b/src/tests/profiling/test_services.py
@@ -1,0 +1,676 @@
+"""Tests for the ProfilingService orchestrator, BH correction, and p-value extraction."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd  # type: ignore[import-untyped]
+import pytest
+
+from src.app.profiling.application.services import (
+    ProfilingService,
+    _apply_bh_correction,
+    _extract_inferential_pvalues,
+)
+from src.app.profiling.domain.value_objects import (
+    AssetBarProfile,
+    AutocorrelationConfig,
+    AutocorrelationProfile,
+    BDSResult,
+    CorrectedPValue,
+    DistributionConfig,
+    LjungBoxResult,
+    PredictabilityConfig,
+    ProfilingConfig,
+    SampleTier,
+    SignBiasResult,
+    StatisticalReport,
+    TierConfig,
+    VolatilityConfig,
+    VolatilityProfile,
+)
+
+
+# ---------------------------------------------------------------------------
+# FakeDataLoader — duck-typed replacement for DataLoader
+# ---------------------------------------------------------------------------
+
+
+class FakeDataLoader:
+    """Fake DataLoader returning synthetic data for testing without a database."""
+
+    def __init__(
+        self,
+        ohlcv_data: dict[tuple[str, str], pd.DataFrame] | None = None,
+        bar_data: dict[tuple[str, str, str], pd.DataFrame] | None = None,
+    ) -> None:
+        """Initialise with pre-built dictionaries of OHLCV and bar data.
+
+        Args:
+            ohlcv_data: Mapping from ``(asset, timeframe)`` to DataFrame.
+            bar_data: Mapping from ``(asset, bar_type, config_hash)`` to DataFrame.
+        """
+        self._ohlcv: dict[tuple[str, str], pd.DataFrame] = ohlcv_data or {}
+        self._bars: dict[tuple[str, str, str], pd.DataFrame] = bar_data or {}
+
+    def load_ohlcv(
+        self,
+        asset: str,
+        timeframe: str,
+        date_range: tuple | None = None,  # noqa: ARG002
+    ) -> pd.DataFrame:
+        """Return OHLCV data for the given asset and timeframe.
+
+        Args:
+            asset: Trading pair symbol.
+            timeframe: Candlestick interval.
+            date_range: Ignored in fake.
+
+        Returns:
+            DataFrame with OHLCV columns, or empty DataFrame.
+        """
+        key: tuple[str, str] = (asset, timeframe)
+        if key in self._ohlcv:
+            return self._ohlcv[key].copy()
+        return pd.DataFrame(columns=["timestamp", "open", "high", "low", "close", "volume"])
+
+    def load_bars(
+        self,
+        asset: str,
+        bar_type: str,
+        config_hash: str,
+        date_range: tuple | None = None,  # noqa: ARG002
+    ) -> pd.DataFrame:
+        """Return bar data for the given asset, bar type, and config hash.
+
+        Args:
+            asset: Trading pair symbol.
+            bar_type: Bar aggregation type.
+            config_hash: Bar configuration hash.
+            date_range: Ignored in fake.
+
+        Returns:
+            DataFrame with bar columns, or empty DataFrame.
+        """
+        key: tuple[str, str, str] = (asset, bar_type, config_hash)
+        if key in self._bars:
+            return self._bars[key].copy()
+        return pd.DataFrame(
+            columns=[
+                "start_ts",
+                "end_ts",
+                "open",
+                "high",
+                "low",
+                "close",
+                "volume",
+                "tick_count",
+                "buy_volume",
+                "sell_volume",
+                "vwap",
+            ]
+        )
+
+    def get_available_assets(self) -> list[str]:
+        """Return sorted list of unique asset symbols across OHLCV and bar data.
+
+        Returns:
+            Sorted list of asset symbol strings.
+        """
+        assets: set[str] = set()
+        for asset, _ in self._ohlcv:
+            assets.add(asset)
+        for asset, _, _ in self._bars:
+            assets.add(asset)
+        return sorted(assets)
+
+    def get_available_bar_configs(self, asset: str) -> list[tuple[str, str]]:
+        """Return bar configs for the given asset.
+
+        Args:
+            asset: Trading pair symbol.
+
+        Returns:
+            Sorted list of ``(bar_type, config_hash)`` tuples.
+        """
+        configs: list[tuple[str, str]] = []
+        for a, bt, ch in self._bars:
+            if a == asset:
+                configs.append((bt, ch))
+        return sorted(configs)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic data factory
+# ---------------------------------------------------------------------------
+
+
+def _make_ohlcv_df(
+    n: int = 2500,
+    seed: int = 42,
+    ts_col: str = "timestamp",
+) -> pd.DataFrame:
+    """Generate synthetic OHLCV data for testing.
+
+    Args:
+        n: Number of bars to generate.
+        seed: Random seed for reproducibility.
+        ts_col: Name for the timestamp column.
+
+    Returns:
+        DataFrame with timestamp, OHLCV columns.
+    """
+    rng: np.random.Generator = np.random.default_rng(seed)
+    timestamps: pd.DatetimeIndex = pd.date_range("2020-01-01", periods=n, freq="h", tz="UTC")
+    close: np.ndarray = 100 * np.exp(np.cumsum(rng.normal(0, 0.001, n)))  # type: ignore[type-arg]
+    return pd.DataFrame(
+        {
+            ts_col: timestamps,
+            "open": close * (1 + rng.normal(0, 0.001, n)),
+            "high": close * (1 + abs(rng.normal(0, 0.002, n))),
+            "low": close * (1 - abs(rng.normal(0, 0.002, n))),
+            "close": close,
+            "volume": rng.uniform(100, 1000, n),
+        }
+    )
+
+
+def _make_bar_df(
+    n: int = 2500,
+    seed: int = 42,
+) -> pd.DataFrame:
+    """Generate synthetic bar data for testing.
+
+    Args:
+        n: Number of bars to generate.
+        seed: Random seed for reproducibility.
+
+    Returns:
+        DataFrame with start_ts, end_ts, OHLCV, and bar-specific columns.
+    """
+    rng: np.random.Generator = np.random.default_rng(seed)
+    timestamps: pd.DatetimeIndex = pd.date_range("2020-01-01", periods=n, freq="h", tz="UTC")
+    close: np.ndarray = 100 * np.exp(np.cumsum(rng.normal(0, 0.001, n)))  # type: ignore[type-arg]
+    return pd.DataFrame(
+        {
+            "start_ts": timestamps,
+            "end_ts": timestamps + pd.Timedelta(hours=1),
+            "open": close * (1 + rng.normal(0, 0.001, n)),
+            "high": close * (1 + abs(rng.normal(0, 0.002, n))),
+            "low": close * (1 - abs(rng.normal(0, 0.002, n))),
+            "close": close,
+            "volume": rng.uniform(100, 1000, n),
+            "tick_count": rng.integers(10, 100, n),
+            "buy_volume": rng.uniform(50, 500, n),
+            "sell_volume": rng.uniform(50, 500, n),
+            "vwap": close * (1 + rng.normal(0, 0.0005, n)),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_loader_single() -> FakeDataLoader:
+    """Build a FakeDataLoader with one asset, one bar type, and one OHLCV timeframe.
+
+    Returns:
+        FakeDataLoader pre-loaded with BTCUSDT data.
+    """
+    ohlcv: dict[tuple[str, str], pd.DataFrame] = {("BTCUSDT", "1h"): _make_ohlcv_df(n=2500, seed=42)}
+    bars: dict[tuple[str, str, str], pd.DataFrame] = {
+        ("BTCUSDT", "dollar", "abc123"): _make_bar_df(n=2500, seed=43),
+    }
+    return FakeDataLoader(ohlcv_data=ohlcv, bar_data=bars)
+
+
+@pytest.fixture
+def fake_loader_multi() -> FakeDataLoader:
+    """Build a FakeDataLoader with two assets, each with one bar type.
+
+    Returns:
+        FakeDataLoader with BTCUSDT and ETHUSDT data.
+    """
+    ohlcv: dict[tuple[str, str], pd.DataFrame] = {
+        ("BTCUSDT", "1h"): _make_ohlcv_df(n=1500, seed=42),
+        ("ETHUSDT", "1h"): _make_ohlcv_df(n=1500, seed=43),
+    }
+    bars: dict[tuple[str, str, str], pd.DataFrame] = {
+        ("BTCUSDT", "dollar", "abc123"): _make_bar_df(n=1500, seed=44),
+        ("ETHUSDT", "volume", "def456"): _make_bar_df(n=1500, seed=45),
+    }
+    return FakeDataLoader(ohlcv_data=ohlcv, bar_data=bars)
+
+
+@pytest.fixture
+def fake_loader_empty() -> FakeDataLoader:
+    """Build a FakeDataLoader with no data at all.
+
+    Returns:
+        Empty FakeDataLoader.
+    """
+    return FakeDataLoader()
+
+
+@pytest.fixture
+def fake_loader_no_bars() -> FakeDataLoader:
+    """Build a FakeDataLoader with OHLCV data but no aggregated bars.
+
+    Returns:
+        FakeDataLoader with only BTCUSDT OHLCV data.
+    """
+    ohlcv: dict[tuple[str, str], pd.DataFrame] = {("BTCUSDT", "1h"): _make_ohlcv_df(n=1000, seed=42)}
+    return FakeDataLoader(ohlcv_data=ohlcv, bar_data={})
+
+
+# ---------------------------------------------------------------------------
+# Test: ProfilingConfig
+# ---------------------------------------------------------------------------
+
+
+class TestProfilingConfig:
+    """Tests for the ProfilingConfig composite config model."""
+
+    def test_defaults(self) -> None:
+        """All sub-configs should use their default values."""
+        cfg: ProfilingConfig = ProfilingConfig()
+        assert isinstance(cfg.distribution, DistributionConfig)
+        assert isinstance(cfg.autocorrelation, AutocorrelationConfig)
+        assert isinstance(cfg.volatility, VolatilityConfig)
+        assert isinstance(cfg.predictability, PredictabilityConfig)
+        assert isinstance(cfg.tier, TierConfig)
+        assert cfg.fdr_alpha == 0.05
+        assert cfg.stationarity_alpha == 0.05
+
+    def test_immutability(self) -> None:
+        """Frozen model should reject attribute assignment."""
+        cfg: ProfilingConfig = ProfilingConfig()
+        with pytest.raises(Exception):  # noqa: B017, PT011
+            cfg.fdr_alpha = 0.1  # type: ignore[misc]
+
+    def test_custom_sub_configs(self) -> None:
+        """Custom sub-config values should propagate correctly."""
+        custom_dist: DistributionConfig = DistributionConfig(jb_alpha=0.01)
+        custom_tier: TierConfig = TierConfig(tier_a_threshold=3000, tier_b_threshold=800)
+        cfg: ProfilingConfig = ProfilingConfig(
+            distribution=custom_dist,
+            tier=custom_tier,
+            fdr_alpha=0.10,
+        )
+        assert cfg.distribution.jb_alpha == 0.01
+        assert cfg.tier.tier_a_threshold == 3000
+        assert cfg.fdr_alpha == 0.10
+
+
+# ---------------------------------------------------------------------------
+# Test: CorrectedPValue
+# ---------------------------------------------------------------------------
+
+
+class TestCorrectedPValue:
+    """Tests for the CorrectedPValue frozen model."""
+
+    def test_creation(self) -> None:
+        """Valid CorrectedPValue should be constructable with all fields."""
+        pv: CorrectedPValue = CorrectedPValue(
+            asset="BTCUSDT",
+            bar_type="dollar",
+            test_name="ljung_box_returns",
+            parameter="lag=5",
+            raw_pvalue=0.03,
+            corrected_pvalue=0.06,
+            significant_raw=True,
+            significant_corrected=False,
+        )
+        assert pv.asset == "BTCUSDT"
+        assert pv.raw_pvalue == 0.03
+
+    def test_fields_accessible(self) -> None:
+        """All fields should be accessible on a frozen instance."""
+        pv: CorrectedPValue = CorrectedPValue(
+            asset="ETHUSDT",
+            bar_type="volume",
+            test_name="bds",
+            parameter="dim=3",
+            raw_pvalue=0.001,
+            corrected_pvalue=0.005,
+            significant_raw=True,
+            significant_corrected=True,
+        )
+        assert pv.test_name == "bds"
+        assert pv.parameter == "dim=3"
+        assert pv.corrected_pvalue == 0.005
+        assert pv.significant_corrected is True
+
+
+# ---------------------------------------------------------------------------
+# Test: BH Correction
+# ---------------------------------------------------------------------------
+
+
+class TestBHCorrection:
+    """Tests for the Benjamini-Hochberg FDR correction helper."""
+
+    def _make_pv(self, raw: float, test: str = "test", param: str = "p") -> CorrectedPValue:
+        """Build a CorrectedPValue with raw significance at alpha=0.05.
+
+        Args:
+            raw: Raw p-value.
+            test: Test name.
+            param: Parameter string.
+
+        Returns:
+            CorrectedPValue with corrected_pvalue initialised to raw.
+        """
+        return CorrectedPValue(
+            asset="BTCUSDT",
+            bar_type="dollar",
+            test_name=test,
+            parameter=param,
+            raw_pvalue=raw,
+            corrected_pvalue=raw,
+            significant_raw=raw < 0.05,
+            significant_corrected=raw < 0.05,
+        )
+
+    def test_single_pvalue(self) -> None:
+        """Single test correction should equal the raw p-value."""
+        raw: list[CorrectedPValue] = [self._make_pv(0.03)]
+        corrected: tuple[CorrectedPValue, ...] = _apply_bh_correction(raw, alpha=0.05)
+        assert len(corrected) == 1
+        assert corrected[0].corrected_pvalue == pytest.approx(0.03, abs=1e-10)
+
+    def test_multiple_pvalues_corrected_ge_raw(self) -> None:
+        """Corrected p-values should always be >= raw p-values."""
+        raw: list[CorrectedPValue] = [
+            self._make_pv(0.01, param="a"),
+            self._make_pv(0.03, param="b"),
+            self._make_pv(0.04, param="c"),
+            self._make_pv(0.50, param="d"),
+        ]
+        corrected: tuple[CorrectedPValue, ...] = _apply_bh_correction(raw, alpha=0.05)
+        assert len(corrected) == 4
+        for orig, corr in zip(raw, corrected, strict=True):
+            assert corr.corrected_pvalue >= orig.raw_pvalue - 1e-10
+
+    def test_monotonicity(self) -> None:
+        """Corrected p-values sorted by raw should be monotonically non-decreasing."""
+        raw: list[CorrectedPValue] = [
+            self._make_pv(0.001, param="a"),
+            self._make_pv(0.01, param="b"),
+            self._make_pv(0.02, param="c"),
+            self._make_pv(0.10, param="d"),
+        ]
+        corrected: tuple[CorrectedPValue, ...] = _apply_bh_correction(raw, alpha=0.05)
+        sorted_corr: list[CorrectedPValue] = sorted(corrected, key=lambda x: x.raw_pvalue)
+        for i in range(len(sorted_corr) - 1):
+            assert sorted_corr[i].corrected_pvalue <= sorted_corr[i + 1].corrected_pvalue + 1e-10
+
+    def test_empty_input(self) -> None:
+        """Empty input should return an empty tuple."""
+        corrected: tuple[CorrectedPValue, ...] = _apply_bh_correction([], alpha=0.05)
+        assert corrected == ()
+
+
+# ---------------------------------------------------------------------------
+# Test: P-value extraction
+# ---------------------------------------------------------------------------
+
+
+class TestPValueExtraction:
+    """Tests for _extract_inferential_pvalues."""
+
+    def _make_lb_results(self) -> tuple[LjungBoxResult, ...]:
+        """Build two Ljung-Box results (one significant, one not).
+
+        Returns:
+            Tuple of two LjungBoxResult objects.
+        """
+        return (
+            LjungBoxResult(lag=5, q_statistic=10.0, p_value=0.02, significant=True),
+            LjungBoxResult(lag=10, q_statistic=15.0, p_value=0.08, significant=False),
+        )
+
+    def test_extracts_ljung_box(self) -> None:
+        """Ljung-Box p-values from both returns and squared returns should be extracted."""
+        acf_profile: AutocorrelationProfile = AutocorrelationProfile(
+            asset="BTCUSDT",
+            bar_type="dollar",
+            tier=SampleTier.A,
+            n_observations=1000,
+            acf_values=np.array([1.0, 0.1]),
+            pacf_values=np.array([1.0, 0.1]),
+            acf_squared_values=np.array([1.0, 0.2]),
+            pacf_squared_values=np.array([1.0, 0.2]),
+            ljung_box_returns=self._make_lb_results(),
+            ljung_box_squared=self._make_lb_results(),
+            has_serial_correlation=True,
+            has_volatility_clustering=True,
+        )
+        profile: AssetBarProfile = AssetBarProfile(
+            asset="BTCUSDT",
+            bar_type="dollar",
+            tier=SampleTier.A,
+            n_observations=1000,
+            autocorrelation=acf_profile,
+        )
+        pvals: list[CorrectedPValue] = _extract_inferential_pvalues(profile)
+        lb_pvals: list[CorrectedPValue] = [p for p in pvals if p.test_name.startswith("ljung_box")]
+        assert len(lb_pvals) == 4  # 2 returns + 2 squared
+
+    def test_extracts_bds(self) -> None:
+        """BDS test p-values should be extracted from the volatility sub-profile."""
+        bds_results: tuple[BDSResult, ...] = (
+            BDSResult(dimension=2, bds_statistic=3.0, p_value=0.001, significant=True),
+            BDSResult(dimension=3, bds_statistic=2.5, p_value=0.01, significant=True),
+        )
+        vol_profile: VolatilityProfile = VolatilityProfile(
+            asset="BTCUSDT",
+            bar_type="time_1h",
+            tier=SampleTier.A,
+            n_observations=2000,
+            is_time_bar=True,
+            bds_results=bds_results,
+        )
+        profile: AssetBarProfile = AssetBarProfile(
+            asset="BTCUSDT",
+            bar_type="time_1h",
+            tier=SampleTier.A,
+            n_observations=2000,
+            volatility=vol_profile,
+        )
+        pvals: list[CorrectedPValue] = _extract_inferential_pvalues(profile)
+        bds_pvals: list[CorrectedPValue] = [p for p in pvals if p.test_name == "bds"]
+        assert len(bds_pvals) == 2
+
+    def test_extracts_sign_bias_and_arch_lm(self) -> None:
+        """Sign bias and ARCH-LM p-values should be extracted from volatility sub-profile."""
+        sign_bias: SignBiasResult = SignBiasResult(
+            sign_bias_tstat=2.1,
+            sign_bias_pvalue=0.03,
+            neg_size_bias_tstat=1.5,
+            neg_size_bias_pvalue=0.13,
+            pos_size_bias_tstat=0.8,
+            pos_size_bias_pvalue=0.42,
+            joint_f_stat=3.5,
+            joint_f_pvalue=0.01,
+            has_leverage_effect=True,
+        )
+        vol_profile: VolatilityProfile = VolatilityProfile(
+            asset="BTCUSDT",
+            bar_type="time_1h",
+            tier=SampleTier.A,
+            n_observations=2000,
+            is_time_bar=True,
+            arch_lm_stat=15.0,
+            arch_lm_pvalue=0.001,
+            sign_bias=sign_bias,
+        )
+        profile: AssetBarProfile = AssetBarProfile(
+            asset="BTCUSDT",
+            bar_type="time_1h",
+            tier=SampleTier.A,
+            n_observations=2000,
+            volatility=vol_profile,
+        )
+        pvals: list[CorrectedPValue] = _extract_inferential_pvalues(profile)
+        arch_pvals: list[CorrectedPValue] = [p for p in pvals if p.test_name == "arch_lm"]
+        sb_pvals: list[CorrectedPValue] = [p for p in pvals if p.test_name == "sign_bias_joint"]
+        assert len(arch_pvals) == 1
+        assert len(sb_pvals) == 1
+
+    def test_none_profiles_skipped(self) -> None:
+        """Profiles with no sub-profiles should produce zero p-values."""
+        profile: AssetBarProfile = AssetBarProfile(
+            asset="BTCUSDT",
+            bar_type="dollar",
+            tier=SampleTier.C,
+            n_observations=100,
+        )
+        pvals: list[CorrectedPValue] = _extract_inferential_pvalues(profile)
+        assert len(pvals) == 0
+
+
+# ---------------------------------------------------------------------------
+# Test: ProfilingService
+# ---------------------------------------------------------------------------
+
+
+class TestProfilingService:
+    """Tests for the ProfilingService orchestrator."""
+
+    def test_profile_single(self, fake_loader_single: FakeDataLoader) -> None:
+        """Single asset-bar profile should have all sub-profiles populated."""
+        service: ProfilingService = ProfilingService(fake_loader_single)  # type: ignore[arg-type]
+        profile: AssetBarProfile = service.profile_single(
+            asset="BTCUSDT",
+            bar_type="dollar",
+            config_hash="abc123",
+        )
+        assert profile.asset == "BTCUSDT"
+        assert profile.bar_type == "dollar"
+        assert profile.n_observations > 0
+        assert profile.distribution is not None
+        assert profile.autocorrelation is not None
+        assert profile.volatility is not None
+        assert profile.predictability is not None
+
+    def test_profile_single_time_bar(self, fake_loader_single: FakeDataLoader) -> None:
+        """Time_1h bar should be loaded from OHLCV data successfully."""
+        service: ProfilingService = ProfilingService(fake_loader_single)  # type: ignore[arg-type]
+        profile: AssetBarProfile = service.profile_single(
+            asset="BTCUSDT",
+            bar_type="time_1h",
+        )
+        assert profile.asset == "BTCUSDT"
+        assert profile.bar_type == "time_1h"
+        assert profile.n_observations > 0
+
+    def test_profile_all_multiple_assets(self, fake_loader_multi: FakeDataLoader) -> None:
+        """Multiple assets should produce correct number of profiles."""
+        service: ProfilingService = ProfilingService(fake_loader_multi)  # type: ignore[arg-type]
+        report: StatisticalReport = service.profile_all()
+        # 2 assets: BTCUSDT (dollar + time_1h), ETHUSDT (volume + time_1h) = 4 profiles
+        assert len(report.profiles) == 4
+        assert report.n_assets == 2
+
+    def test_tier_classification(self, fake_loader_single: FakeDataLoader) -> None:
+        """2500 bars minus 1 for log returns should classify as Tier A."""
+        service: ProfilingService = ProfilingService(fake_loader_single)  # type: ignore[arg-type]
+        profile: AssetBarProfile = service.profile_single(
+            asset="BTCUSDT",
+            bar_type="dollar",
+            config_hash="abc123",
+        )
+        assert profile.tier == SampleTier.A
+
+    def test_statistical_report_summary(self, fake_loader_single: FakeDataLoader) -> None:
+        """Summary counts should be internally consistent after FDR correction."""
+        service: ProfilingService = ProfilingService(fake_loader_single)  # type: ignore[arg-type]
+        report: StatisticalReport = service.profile_all(assets=["BTCUSDT"])
+        # 1 asset: dollar + time_1h = 2 profiles
+        assert len(report.profiles) == 2
+        assert report.n_total_tests >= 0
+        assert report.n_significant_raw >= report.n_significant_corrected
+
+    def test_fdr_correction_applied(self, fake_loader_single: FakeDataLoader) -> None:
+        """Corrected p-values should exist and be >= raw p-values."""
+        service: ProfilingService = ProfilingService(fake_loader_single)  # type: ignore[arg-type]
+        report: StatisticalReport = service.profile_all(assets=["BTCUSDT"])
+        assert len(report.corrected_pvalues) > 0
+        for cpv in report.corrected_pvalues:
+            assert cpv.corrected_pvalue >= cpv.raw_pvalue - 1e-10
+
+
+# ---------------------------------------------------------------------------
+# Test: StatisticalReport
+# ---------------------------------------------------------------------------
+
+
+class TestStatisticalReport:
+    """Tests for the StatisticalReport frozen model."""
+
+    def test_creation(self) -> None:
+        """Empty StatisticalReport should be constructable."""
+        report: StatisticalReport = StatisticalReport(
+            profiles=(),
+            corrected_pvalues=(),
+            n_assets=0,
+            n_bar_types=0,
+            n_total_tests=0,
+            n_significant_raw=0,
+            n_significant_corrected=0,
+        )
+        assert report.n_total_tests == 0
+        assert report.profiles == ()
+
+    def test_summary_counts_constraint(self, fake_loader_single: FakeDataLoader) -> None:
+        """BH correction should not increase the number of significant tests."""
+        service: ProfilingService = ProfilingService(fake_loader_single)  # type: ignore[arg-type]
+        report: StatisticalReport = service.profile_all(assets=["BTCUSDT"])
+        assert report.n_significant_raw >= report.n_significant_corrected
+
+
+# ---------------------------------------------------------------------------
+# Test: Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Tests for edge cases: empty data, no bar configs, small samples."""
+
+    def test_empty_data(self, fake_loader_empty: FakeDataLoader) -> None:
+        """Empty DataFrame should produce a Tier C profile with zero observations."""
+        service: ProfilingService = ProfilingService(fake_loader_empty)  # type: ignore[arg-type]
+        profile: AssetBarProfile = service.profile_single(
+            asset="BTCUSDT",
+            bar_type="dollar",
+            config_hash="abc123",
+        )
+        assert profile.n_observations == 0
+        assert profile.tier == SampleTier.C
+
+    def test_no_bar_configs(self, fake_loader_no_bars: FakeDataLoader) -> None:
+        """Asset with no aggregated bars should only produce a time_1h profile."""
+        service: ProfilingService = ProfilingService(fake_loader_no_bars)  # type: ignore[arg-type]
+        report: StatisticalReport = service.profile_all(assets=["BTCUSDT"])
+        assert len(report.profiles) == 1
+        assert report.profiles[0].bar_type == "time_1h"
+
+    def test_single_row_data(self) -> None:
+        """Single-row DataFrame should produce zero observations (no returns after diff)."""
+        ohlcv: dict[tuple[str, str], pd.DataFrame] = {("BTCUSDT", "1h"): _make_ohlcv_df(n=1, seed=42)}
+        loader: FakeDataLoader = FakeDataLoader(ohlcv_data=ohlcv)
+        service: ProfilingService = ProfilingService(loader)  # type: ignore[arg-type]
+        profile: AssetBarProfile = service.profile_single(asset="BTCUSDT", bar_type="time_1h")
+        assert profile.n_observations == 0
+
+    def test_small_sample_tier_c(self) -> None:
+        """50 rows minus 1 for returns should classify as Tier C."""
+        ohlcv: dict[tuple[str, str], pd.DataFrame] = {("BTCUSDT", "1h"): _make_ohlcv_df(n=50, seed=42)}
+        loader: FakeDataLoader = FakeDataLoader(ohlcv_data=ohlcv)
+        service: ProfilingService = ProfilingService(loader)  # type: ignore[arg-type]
+        profile: AssetBarProfile = service.profile_single(asset="BTCUSDT", bar_type="time_1h")
+        assert profile.tier == SampleTier.C


### PR DESCRIPTION
## Summary
- **`ProfilingService`** orchestrator that iterates over all (asset, bar_type) combinations, dispatches to all Phase 5 analyzers (distribution, serial dependence, volatility, predictability, stationarity), and aggregates results into a `StatisticalReport`
- **`ProfilingConfig`** composite frozen config holding all sub-analyzer configs + tier thresholds + FDR alpha
- **Benjamini-Hochberg FDR correction** applied across the full grid of inferential test p-values (Ljung-Box, variance ratio, Granger, BDS, ARCH-LM, sign bias) — reports both raw and corrected p-values via `CorrectedPValue` value objects
- **`AssetBarProfile`** aggregates all sub-profiles per (asset, bar_type), **`StatisticalReport`** provides cross-asset summary with significance counts
- 4 new value objects, 1 new service module, **25 tests** across 7 classes — all passing
- Uses `FakeDataLoader` (duck-typed) for tests — no database dependency

Closes #42

## Test plan
- [x] `just test src/tests/profiling/test_services.py` — 25/25 pass
- [x] `just test src/tests/profiling/` — 180/180 pass (no regressions)
- [x] `just lint` — ruff format, ruff lint, pyright all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)