### PR TITLE
feat(backtest): core domain model + migrate pyright to ty (#80)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Ruff lint (includes import sorting)
         run: uv run ruff check --config=pyproject.toml .
 
-      - name: Pyright
-        run: uv run pyright --project=pyproject.toml
+      - name: ty
+        run: uv run ty check src/ --exclude 'src/tests/**' --exclude 'src/app/research/**'
 
   test:
     name: Tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,12 +15,11 @@ repos:
           - --fix
           - --config=pyproject.toml
 
-  - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.408
+  - repo: local
     hooks:
-      - id: pyright
-        name: Type checker (pyright)
-        language: python
-        require_serial: true
-        args:
-          - --project=pyproject.toml
+      - id: ty
+        name: Type checker (ty)
+        entry: uv run ty check src/ --exclude src/tests/** --exclude src/app/research/**
+        language: system
+        pass_filenames: false
+        types: [python]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ```bash
 # Development
 just run                    # Run main.py
-just lint                   # Run all pre-commit hooks (ruff format + ruff lint + pyright)
+just lint                   # Run all pre-commit hooks (ruff format + ruff lint + ty)
 just test                   # Run full test suite (uv run pytest src/tests/)
 just test src/tests/research/  # Run specific test module
 just test -k "test_name"    # Run single test by name
@@ -106,7 +106,7 @@ Tests mirror the source structure under `src/tests/<module>/`. Pytest markers: `
 |-------|------|------|
 | 1 | Formatter | `ruff format` (119 char lines, double quotes) |
 | 2 | Linter | `ruff` (~25 rule categories incl. `D`, `DOC`, `ANN`, `S`, `N`, `PERF`) |
-| 3 | Type checker | `pyright` (strict for `src/`, excludes `src/tests/` and `src/app/research/`) |
+| 3 | Type checker | `ty` (Astral, excludes `src/tests/` and `src/app/research/`) |
 
 Import sorting is handled by ruff's `I` rules (no separate isort hook). All config in `pyproject.toml`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,12 +61,12 @@ infrastructure/  # Concrete implementations — depends on domain + external lib
 | `ohlcv/` | ✅ | OHLCV domain entities, repository, service |
 | `ingestion/` | ✅ | Binance API client, ingestion service, CLI (`src/app/ingestion/cli.py`) |
 | `bars/` | ✅ | Lopez de Prado alternative bars (tick, volume, dollar, imbalance, run) + CLI (`src/app/bars/cli.py`) |
-| `research/` | ✅ | RC1 analysis services (coverage, returns, ACF, bar comparison, charts) |
+| `research/` | ✅ | RC1–RC2 analysis services (coverage, returns, ACF, bar comparison, charts) |
 | `features/` | ✅ | Feature engineering (indicators, targets, matrix builder) + validation (MI, BH, DA) |
-| `profiling/` | Phase 5 | Statistical profiling per asset |
-| `backtest/` | Phase 7 | Event-driven backtest engine |
-| `strategy/` | Phase 8 | Base trading strategies |
-| `forecasting/` | Phase 9–10 | Classification + regression models |
+| `profiling/` | ✅ | Statistical profiling per asset (distributions, serial dependence, volatility, stationarity) |
+| `backtest/` | Phase 8 🔧 | Event-driven backtest engine (domain model done, execution + metrics next) |
+| `strategy/` | Phase 9 | Base trading strategies |
+| `forecasting/` | Phase 10–11 | Classification + regression models |
 | `recommendation/` | Phase 12 | ML recommendation system |
 | `evaluation/` | Phase 14 | Monte Carlo, permutation tests, statistical proof |
 
@@ -117,6 +117,7 @@ Import sorting is handled by ruff's `I` rules (no separate isort hook). All conf
 - **All local variables** must have explicit type annotations (project convention, not enforced by linter)
 - No `Any` unless interfacing with untyped third-party libs (comment why)
 - `from __future__ import annotations` in every file
+- Type-ignore comments: use `# type: ignore[rule]` (for pyright compat) AND `# ty: ignore[rule]` side-by-side when suppressing third-party typing issues
 
 ### Docstrings — Google style (enforced by Ruff `D` + `DOC`)
 
@@ -140,16 +141,21 @@ See `pyproject.toml` `[tool.ruff.lint.per-file-ignores]` for the full list. Key 
 7. **Honest evaluation:** Negative results are valid and documented.
 8. **Config-driven:** Every parameter in Pydantic config classes. No magic numbers.
 
-## Current Progress (Phases 1–4 complete)
+## Current Progress (Phases 1–7 complete, Phase 8 in progress)
 
-**RC1 findings** (see `research/RC1_analysis.md`):
-- **Assets:** BTCUSDT, ETHUSDT, LTCUSDT, SOLUSDT (all pass quality filters, >99.9% coverage)
-- **Bar types for Phase 4:** dollar (primary, N=5,286), volume (N=3,264), volume_imbalance (N=530), dollar_imbalance (N=568), time_1h (baseline)
-- **Disqualified:** tick bars (threshold too high, ≤55 bars), run bars (extreme kurtosis 30–43)
+**Completed phases:**
+- **Phase 1:** Data ingestion pipeline (Binance API → DuckDB)
+- **Phase 2:** Alternative bar construction (López de Prado tick/volume/dollar/imbalance/run bars)
+- **Phase 3 (RC1):** Data quality & bar analysis — 4 assets selected (BTCUSDT, ETHUSDT, LTCUSDT, SOLUSDT)
+- **Phase 4:** Feature engineering + validation pipeline (MI, BH correction, DA, DC-MAE, temporal stability)
+- **Phase 5:** Statistical profiling (return distributions, serial dependence, volatility modeling, stationarity)
+- **Phase 6 (RC2):** Features & data adequacy audit — 6 audit gaps identified
+- **Phase 7:** All 6 RC2 audit gaps resolved (cost sensitivity, constant-feature fix, stationarity policy, MI normalization, LTCUSDT volume-bar profiling, SOLUSDT tier-B protocol). See `research/RC7_analysis.md`.
 
-**Phase 4 complete:** Feature engineering (indicators, targets, matrix builder) + validation pipeline (MI permutation tests, Benjamini-Hochberg correction, directional accuracy, DC-MAE, temporal stability). See `4d_report.md` for validation review.
-
-- **Next:** Phase 5 (Statistical Profiling)
+**Phase 8 (in progress):** Backtest engine
+- **8A done:** Domain model (`backtest/domain/`) — `Side`, `ExecutionConfig`, `TradeResult`, `PortfolioSnapshot`, `Signal`, `Position`, `Trade`, `EquityCurve`, `IStrategy`, `IPositionSizer`
+- **8B next:** Execution layer (fill on next bar open, cost sweep)
+- **8C next:** Metrics layer (Sharpe with Lo 2002 correction, drawdown, trade stats)
 
 ## What NOT to Do
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,15 +33,6 @@ dependencies = [
     "typer>=0.24.1",
 ]
 
-[tool.pyright]
-include = ["src"]
-exclude = ["src/tests/*", "src/app/research/*"]
-venvPath = "."
-venv = ".venv"
-reportMissingImports = true
-reportMissingTypeStubs = true
-reportPrivateUsage = true
-
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.
 exclude = [
@@ -201,7 +192,7 @@ dev = [
     "ipykernel>=7.2.0",
     "isort>=8.0.1",
     "jupyterlab>=4.5.6",
-    "pyright>=1.1.408",
     "pytest>=9.0.2",
     "ruff>=0.15.4",
+    "ty>=0.0.26",
 ]

--- a/src/app/backtest/__init__.py
+++ b/src/app/backtest/__init__.py
@@ -1,0 +1,1 @@
+"""Event-driven backtest engine module."""

--- a/src/app/backtest/domain/__init__.py
+++ b/src/app/backtest/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Backtest domain layer."""

--- a/src/app/backtest/domain/entities.py
+++ b/src/app/backtest/domain/entities.py
@@ -1,0 +1,175 @@
+"""Backtest domain entities — signals, positions, trades, equity curves."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated, Self
+
+from pydantic import BaseModel
+from pydantic import Field as PydanticField
+from pydantic import model_validator
+
+from src.app.backtest.domain.value_objects import Side, TradeResult
+from src.app.ohlcv.domain.value_objects import Asset
+
+
+# ---------------------------------------------------------------------------
+# Signal
+# ---------------------------------------------------------------------------
+
+
+class Signal(BaseModel, frozen=True):
+    """A directional trading signal emitted by a strategy.
+
+    Strength ranges from 0 (no conviction) to 1 (maximum conviction)
+    and is consumed by the position sizer to determine trade size.
+
+    Invariants:
+        * ``strength`` must be in the closed interval ``[0, 1]``.
+    """
+
+    asset: Asset
+    side: Side
+    strength: Annotated[
+        float,
+        PydanticField(ge=0.0, le=1.0, description="Signal conviction from 0.0 to 1.0"),
+    ]
+    timestamp: datetime
+
+
+# ---------------------------------------------------------------------------
+# Position
+# ---------------------------------------------------------------------------
+
+
+class Position(BaseModel, frozen=False):
+    """A mutable open position tracked by the backtest engine.
+
+    Unlike :class:`Trade`, a position is *live* — its unrealised P&L
+    is updated on every bar.  Optional stop-loss and take-profit
+    levels are checked by the execution layer.
+
+    Invariants:
+        * ``size`` must be positive.
+        * ``entry_price`` must be positive.
+    """
+
+    asset: Asset
+    side: Side
+    size: Annotated[float, PydanticField(gt=0, description="Position size in base units")]
+    entry_price: Annotated[float, PydanticField(gt=0, description="Average entry price")]
+    entry_time: datetime
+    unrealized_pnl: Annotated[float, PydanticField(default=0.0)]
+    stop_loss: Annotated[float | None, PydanticField(default=None)]
+    take_profit: Annotated[float | None, PydanticField(default=None)]
+
+
+# ---------------------------------------------------------------------------
+# Trade
+# ---------------------------------------------------------------------------
+
+
+class Trade(BaseModel, frozen=True):
+    """Immutable record of a completed trade lifecycle (entry to exit).
+
+    Produced when a :class:`Position` is closed.  Contains full P&L
+    accounting including commissions.
+
+    Invariants:
+        * ``exit_time`` must be strictly after ``entry_time``.
+    """
+
+    asset: Asset
+    side: Side
+    size: Annotated[float, PydanticField(gt=0, description="Trade size in base units")]
+    entry_price: Annotated[float, PydanticField(gt=0, description="Entry fill price")]
+    exit_price: Annotated[float, PydanticField(gt=0, description="Exit fill price")]
+    entry_time: datetime
+    exit_time: datetime
+    gross_pnl: float
+    net_pnl: float
+    commission_paid: Annotated[
+        float,
+        PydanticField(ge=0, description="Total commission paid for the round trip"),
+    ]
+
+    @model_validator(mode="after")
+    def _exit_after_entry(self) -> Self:
+        """Ensure exit time is strictly after entry time.
+
+        Returns:
+            Validated instance.
+
+        Raises:
+            ValueError: If ``exit_time`` is not after ``entry_time``.
+        """
+        if self.exit_time <= self.entry_time:
+            msg: str = f"exit_time ({self.exit_time}) must be after entry_time ({self.entry_time})"
+            raise ValueError(msg)
+        return self
+
+    def to_result(self) -> TradeResult:
+        """Convert to a :class:`TradeResult` value object.
+
+        Strips the :class:`Asset` entity reference, producing a
+        lightweight record suitable for aggregation and serialisation.
+
+        Returns:
+            An equivalent :class:`TradeResult`.
+        """
+        return TradeResult(
+            entry_price=self.entry_price,
+            exit_price=self.exit_price,
+            side=self.side,
+            size=self.size,
+            entry_time=self.entry_time,
+            exit_time=self.exit_time,
+            gross_pnl=self.gross_pnl,
+            net_pnl=self.net_pnl,
+            commission_paid=self.commission_paid,
+        )
+
+
+# ---------------------------------------------------------------------------
+# EquityCurve
+# ---------------------------------------------------------------------------
+
+
+class EquityCurve(BaseModel, frozen=True):
+    """Time-indexed equity series produced by a backtest run.
+
+    Stores aligned lists of timestamps and equity values.  Downstream
+    consumers use this to compute Sharpe ratio, drawdown, and other
+    performance statistics.
+
+    Invariants:
+        * ``timestamps`` and ``values`` must have equal length.
+        * ``timestamps`` must be monotonically increasing.
+    """
+
+    timestamps: list[datetime]
+    values: list[float]
+
+    @model_validator(mode="after")
+    def _validate_alignment_and_ordering(self) -> Self:
+        """Ensure timestamps and values are aligned and chronologically ordered.
+
+        Returns:
+            Validated instance.
+
+        Raises:
+            ValueError: If lengths differ or timestamps are not monotonically
+                increasing.
+        """
+        if len(self.timestamps) != len(self.values):
+            msg: str = f"timestamps length ({len(self.timestamps)}) must equal values length ({len(self.values)})"
+            raise ValueError(msg)
+        for i in range(1, len(self.timestamps)):
+            if self.timestamps[i] <= self.timestamps[i - 1]:
+                msg = (
+                    f"timestamps must be monotonically increasing, but "
+                    f"index {i} ({self.timestamps[i]}) <= index {i - 1} "
+                    f"({self.timestamps[i - 1]})"
+                )
+                raise ValueError(msg)
+        return self

--- a/src/app/backtest/domain/protocols.py
+++ b/src/app/backtest/domain/protocols.py
@@ -1,0 +1,67 @@
+"""Backtest domain protocols — structural interfaces for strategies and position sizing."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Protocol
+
+import polars as pl
+
+from src.app.backtest.domain.entities import Signal
+from src.app.backtest.domain.value_objects import PortfolioSnapshot
+
+
+class IStrategy(Protocol):
+    """Structural interface for trading strategies.
+
+    Implementations receive a bar timestamp, a feature DataFrame, and
+    the current portfolio state, returning zero or more :class:`Signal`
+    objects that the backtest engine routes to the position sizer.
+    """
+
+    def on_bar(
+        self,
+        timestamp: datetime,
+        features: pl.DataFrame,
+        portfolio: PortfolioSnapshot,
+    ) -> list[Signal]:
+        """Generate trading signals for the current bar.
+
+        Args:
+            timestamp: Bar timestamp (UTC).
+            features: Polars DataFrame containing feature columns for the
+                current bar.  Implementations must not look ahead — only
+                rows up to and including *timestamp* are valid.
+            portfolio: Current portfolio state snapshot.
+
+        Returns:
+            List of signals (may be empty if no action is warranted).
+        """
+        ...
+
+
+class IPositionSizer(Protocol):
+    """Structural interface for position sizing algorithms.
+
+    Implementations translate a :class:`Signal` into a concrete position
+    size, accounting for portfolio state and current volatility.
+    """
+
+    def size(
+        self,
+        signal: Signal,
+        portfolio: PortfolioSnapshot,
+        volatility: float,
+    ) -> float:
+        """Compute position size for a given signal.
+
+        Args:
+            signal: Trading signal with direction and conviction strength.
+            portfolio: Current portfolio state (equity, cash, positions).
+            volatility: Current asset volatility estimate (e.g. realised vol
+                over a trailing window).
+
+        Returns:
+            Position size in base asset units.  Zero means no trade.
+        """
+        ...

--- a/src/app/backtest/domain/value_objects.py
+++ b/src/app/backtest/domain/value_objects.py
@@ -1,0 +1,154 @@
+"""Backtest domain value objects — execution config, trade results, portfolio snapshots."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Annotated, Self
+
+from pydantic import BaseModel
+from pydantic import Field as PydanticField
+from pydantic import model_validator
+
+
+# ---------------------------------------------------------------------------
+# Side
+# ---------------------------------------------------------------------------
+
+
+class Side(StrEnum):
+    """Trade direction."""
+
+    LONG = "long"
+    SHORT = "short"
+
+
+# ---------------------------------------------------------------------------
+# ExecutionConfig
+# ---------------------------------------------------------------------------
+
+
+class ExecutionConfig(BaseModel, frozen=True):
+    """Execution-cost configuration for backtest simulations.
+
+    Encapsulates commission assumptions and cost-sweep parameters used by
+    the backtest engine to evaluate strategy robustness across different
+    fee regimes.
+
+    Attributes:
+        commission_bps: Default commission in basis points (1 bp = 0.01%).
+        asset_cost_multiplier: Per-asset cost multipliers that override the
+            default commission.  Keys are asset symbols (e.g. ``"BTCUSDT"``).
+        min_trade_count: Minimum number of trades required for a backtest
+            result to be considered statistically meaningful.
+        cost_sweep_bps: Commission levels (in bps) to sweep over when
+            evaluating cost sensitivity.
+    """
+
+    commission_bps: Annotated[
+        float,
+        PydanticField(default=10, ge=0, description="Default commission in basis points"),
+    ]
+
+    asset_cost_multiplier: Annotated[
+        dict[str, float],
+        PydanticField(
+            default_factory=dict,
+            description="Per-asset cost multipliers overriding the default commission",
+        ),
+    ]
+
+    min_trade_count: Annotated[
+        int,
+        PydanticField(
+            default=30,
+            gt=0,
+            description="Minimum trades for statistical significance",
+        ),
+    ]
+
+    cost_sweep_bps: Annotated[
+        list[float],
+        PydanticField(
+            default_factory=lambda: [5.0, 10.0, 15.0, 20.0, 30.0],
+            description="Commission levels (bps) for cost-sensitivity sweep",
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# TradeResult
+# ---------------------------------------------------------------------------
+
+
+class TradeResult(BaseModel, frozen=True):
+    """Immutable record of a completed trade.
+
+    Captures entry/exit prices, timing, direction, size, and the
+    gross/net P&L after commissions.  Used as the atomic unit for
+    strategy performance aggregation.
+
+    Invariants:
+        * ``exit_time`` must be strictly after ``entry_time``.
+        * ``size`` must be positive.
+        * ``commission_paid`` must be non-negative.
+    """
+
+    entry_price: Annotated[float, PydanticField(gt=0, description="Entry fill price")]
+    exit_price: Annotated[float, PydanticField(gt=0, description="Exit fill price")]
+    side: Side
+    size: Annotated[float, PydanticField(gt=0, description="Position size in base asset units")]
+    entry_time: datetime
+    exit_time: datetime
+    gross_pnl: float
+    net_pnl: float
+    commission_paid: Annotated[
+        float,
+        PydanticField(ge=0, description="Total commission paid for the round trip"),
+    ]
+
+    @model_validator(mode="after")
+    def _exit_after_entry(self) -> Self:
+        """Ensure exit time is strictly after entry time.
+
+        Returns:
+            Validated instance.
+
+        Raises:
+            ValueError: If ``exit_time`` is not after ``entry_time``.
+        """
+        if self.exit_time <= self.entry_time:
+            msg: str = f"exit_time ({self.exit_time}) must be after entry_time ({self.entry_time})"
+            raise ValueError(msg)
+        return self
+
+
+# ---------------------------------------------------------------------------
+# PortfolioSnapshot
+# ---------------------------------------------------------------------------
+
+
+class PortfolioSnapshot(BaseModel, frozen=True):
+    """Point-in-time snapshot of portfolio state.
+
+    Captures equity, cash, open positions, unrealised P&L, and
+    drawdown at a single timestamp.  The backtest engine emits one
+    snapshot per bar to build the equity curve.
+
+    Invariants:
+        * ``equity`` must be non-negative.
+        * ``drawdown`` must be non-positive (zero or negative).
+    """
+
+    timestamp: datetime
+    equity: Annotated[float, PydanticField(ge=0, description="Total portfolio equity")]
+    cash: float
+    positions: Annotated[
+        dict[str, float],
+        PydanticField(
+            default_factory=dict,
+            description="Open positions: asset symbol to signed size",
+        ),
+    ]
+    unrealized_pnl: Annotated[float, PydanticField(default=0.0)]
+    drawdown: Annotated[float, PydanticField(default=0.0, le=0)]

--- a/src/app/features/application/validation.py
+++ b/src/app/features/application/validation.py
@@ -383,7 +383,7 @@ def _assemble_report(  # noqa: PLR0913, PLR0914, PLR0917
         for i, result in enumerate(feature_results):
             if i in top_indices and not result.keep:
                 rebuilt.append(
-                    FeatureValidationResult(**{**result.model_dump(), "keep": True}),
+                    FeatureValidationResult(**{**result.model_dump(), "keep": True}),  # ty: ignore[invalid-argument-type]
                 )
             else:
                 rebuilt.append(result)

--- a/src/app/ingestion/cli.py
+++ b/src/app/ingestion/cli.py
@@ -120,7 +120,7 @@ def _build_service(cm: ConnectionManager) -> IngestionService:
     Returns:
         A fully wired :class:`IngestionService` ready to execute ingestion commands.
     """
-    settings: BinanceSettings = BinanceSettings()  # type: ignore[call-arg]  # populated from env
+    settings: BinanceSettings = BinanceSettings()  # type: ignore[call-arg]  # ty: ignore[missing-argument]  # populated from env
     fetcher: BinanceFetcher = BinanceFetcher(settings)
     repository: DuckDBOHLCVRepository = DuckDBOHLCVRepository(cm)
     return IngestionService(fetcher=fetcher, repository=repository)

--- a/src/app/ingestion/infrastructure/binance_fetcher.py
+++ b/src/app/ingestion/infrastructure/binance_fetcher.py
@@ -197,7 +197,7 @@ class BinanceFetcher:
             BinanceAPIException: On other Binance API errors (retryable).
         """
         try:
-            result: list[list[Any]] = self._client.get_klines(  # type: ignore[assignment]
+            result: list[list[Any]] = self._client.get_klines(  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
                 symbol=symbol,
                 interval=interval.value,
                 startTime=start_time,

--- a/src/app/profiling/application/serial_dependence.py
+++ b/src/app/profiling/application/serial_dependence.py
@@ -218,7 +218,7 @@ def _compute_acf_pacf(
     acf_result: tuple[np.ndarray, np.ndarray] = acf(data, nlags=effective_lag, alpha=0.05)  # type: ignore[type-arg, assignment]
     acf_values: np.ndarray = acf_result[0]  # type: ignore[type-arg]
 
-    pacf_values: np.ndarray = pacf(data, nlags=effective_lag, method="ywm")  # type: ignore[type-arg]
+    pacf_values: np.ndarray = pacf(data, nlags=effective_lag, method="ywm")  # type: ignore[type-arg]  # ty: ignore[invalid-assignment]
 
     return acf_values, pacf_values
 

--- a/src/app/profiling/application/services.py
+++ b/src/app/profiling/application/services.py
@@ -498,7 +498,7 @@ class ProfilingService:
         Returns:
             Filtered Pandas DataFrame ordered by timestamp.
         """
-        date_range: tuple[pd.Timestamp, pd.Timestamp] = (  # type: ignore[assignment]
+        date_range: tuple[pd.Timestamp, pd.Timestamp] = (  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
             partition.feature_selection_start,
             partition.feature_selection_end,
         )

--- a/src/app/profiling/application/volatility.py
+++ b/src/app/profiling/application/volatility.py
@@ -52,7 +52,7 @@ def _fit_single_garch(  # noqa: PLR0913, PLR0917
         returns_pct: pd.Series = returns * 100  # type: ignore[type-arg]
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            am = arch_model(returns_pct, vol="Garch", p=p, q=q, dist=dist, mean="Zero")  # type: ignore[no-untyped-call]
+            am = arch_model(returns_pct, vol="Garch", p=p, q=q, dist=dist, mean="Zero")  # type: ignore[no-untyped-call]  # ty: ignore[invalid-argument-type]
             res = am.fit(disp="off", show_warning=False)  # type: ignore[no-untyped-call]
 
         omega_raw: float = float(res.params["omega"])
@@ -450,7 +450,7 @@ def _get_std_resid(
         returns_pct: pd.Series = returns * 100  # type: ignore[type-arg]
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            am = arch_model(returns_pct, vol="Garch", p=p, q=q, dist=dist, mean="Zero")  # type: ignore[no-untyped-call]
+            am = arch_model(returns_pct, vol="Garch", p=p, q=q, dist=dist, mean="Zero")  # type: ignore[no-untyped-call]  # ty: ignore[invalid-argument-type]
             res = am.fit(disp="off", show_warning=False)  # type: ignore[no-untyped-call]
         return np.asarray(res.std_resid, dtype=np.float64)
     except Exception:
@@ -475,7 +475,7 @@ def _fit_gjr_gamma(
         returns_pct: pd.Series = returns * 100  # type: ignore[type-arg]
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            am = arch_model(returns_pct, vol="GARCH", p=1, o=1, q=1, dist=dist, mean="Zero")  # type: ignore[no-untyped-call]
+            am = arch_model(returns_pct, vol="GARCH", p=1, o=1, q=1, dist=dist, mean="Zero")  # type: ignore[no-untyped-call]  # ty: ignore[invalid-argument-type]
             res = am.fit(disp="off", show_warning=False)  # type: ignore[no-untyped-call]
     except Exception:
         logger.warning("GJR-GARCH fitting failed with dist={}", dist)

--- a/uv.lock
+++ b/uv.lock
@@ -909,6 +909,7 @@ dependencies = [
     { name = "griffecli" },
     { name = "griffelib" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/04/56/28a0accac339c164b52a92c6cfc45a903acc0c174caa5c1713803467b533/griffe-2.0.0.tar.gz", hash = "sha256:c68979cd8395422083a51ea7cf02f9c119d889646d99b7b656ee43725de1b80f", size = 293906, upload-time = "2026-03-23T21:06:53.402Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/94/ee21d41e7eb4f823b94603b9d40f86d3c7fde80eacc2c3c71845476dddaa/griffe-2.0.0-py3-none-any.whl", hash = "sha256:5418081135a391c3e6e757a7f3f156f1a1a746cc7b4023868ff7d5e2f9a980aa", size = 5214, upload-time = "2026-02-09T19:09:44.105Z" },
 ]
@@ -921,6 +922,7 @@ dependencies = [
     { name = "colorama" },
     { name = "griffelib" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/f8/2e129fd4a86e52e58eefe664de05e7d502decf766e7316cc9e70fdec3e18/griffecli-2.0.0.tar.gz", hash = "sha256:312fa5ebb4ce6afc786356e2d0ce85b06c1c20d45abc42d74f0cda65e159f6ef", size = 56213, upload-time = "2026-03-23T21:06:54.8Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ed/d93f7a447bbf7a935d8868e9617cbe1cadf9ee9ee6bd275d3040fbf93d60/griffecli-2.0.0-py3-none-any.whl", hash = "sha256:9f7cd9ee9b21d55e91689358978d2385ae65c22f307a63fb3269acf3f21e643d", size = 9345, upload-time = "2026-02-09T19:09:42.554Z" },
 ]
@@ -929,6 +931,7 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]
@@ -2468,19 +2471,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyright"
-version = "1.1.408"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nodeenv" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
-]
-
-[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2844,9 +2834,9 @@ dev = [
     { name = "ipykernel" },
     { name = "isort" },
     { name = "jupyterlab" },
-    { name = "pyright" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -2884,9 +2874,9 @@ dev = [
     { name = "ipykernel", specifier = ">=7.2.0" },
     { name = "isort", specifier = ">=8.0.1" },
     { name = "jupyterlab", specifier = ">=4.5.6" },
-    { name = "pyright", specifier = ">=1.1.408" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "ruff", specifier = ">=0.15.4" },
+    { name = "ty", specifier = ">=0.0.26" },
 ]
 
 [[package]]
@@ -3203,6 +3193,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/94/4879b81f8681117ccaf31544579304f6dc2ddcc0c67f872afb35869643a2/ty-0.0.26.tar.gz", hash = "sha256:0496b62405d62de7b954d6d677dc1cc5d3046197215d7a0a7fef37745d7b6d29", size = 5393643, upload-time = "2026-03-26T16:27:11.067Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/24/99fe33ecd7e16d23c53b0d4244778c6d1b6eb1663b091236dcba22882d67/ty-0.0.26-py3-none-linux_armv6l.whl", hash = "sha256:35beaa56cf59725fd59ab35d8445bbd40b97fe76db39b052b1fcb31f9bf8adf7", size = 10521856, upload-time = "2026-03-26T16:27:06.335Z" },
+    { url = "https://files.pythonhosted.org/packages/55/97/1b5e939e2ff69b9bb279ab680bfa8f677d886309a1ac8d9588fd6ce58146/ty-0.0.26-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:487a0be58ab0eb02e31ba71eb6953812a0f88e50633469b0c0ce3fb795fe0fa1", size = 10320958, upload-time = "2026-03-26T16:27:13.849Z" },
+    { url = "https://files.pythonhosted.org/packages/71/25/37081461e13d38a190e5646948d7bc42084f7bd1c6b44f12550be3923e7e/ty-0.0.26-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a01b7de5693379646d423b68f119719a1338a20017ba48a93eefaff1ee56f97b", size = 9799905, upload-time = "2026-03-26T16:26:55.805Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/1c/295d8f55a7b0e037dfc3a5ec4bdda3ab3cbca6f492f725bf269f96a4d841/ty-0.0.26-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:628c3ee869d113dd2bd249925662fd39d9d0305a6cb38f640ddaa7436b74a1ef", size = 10317507, upload-time = "2026-03-26T16:27:31.887Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/62/48b3875c5d2f48fe017468d4bbdde1164c76a8184374f1d5e6162cf7d9b8/ty-0.0.26-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:63d04f35f5370cbc91c0b9675dc83e0c53678125a7b629c9c95769e86f123e65", size = 10319821, upload-time = "2026-03-26T16:27:29.647Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/28/cfb2d495046d5bf42d532325cea7412fa1189912d549dbfae417a24fd794/ty-0.0.26-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4a53c4e6f6a91927f8b90e584a4b12bcde05b0c1870ddff8d17462168ad7947a", size = 10831757, upload-time = "2026-03-26T16:27:37.441Z" },
+    { url = "https://files.pythonhosted.org/packages/26/bf/dbc3e42f448a2d862651de070b4108028c543ca18cab096b38d7de449915/ty-0.0.26-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:caf2ced0e58d898d5e3ba5cb843e0ebd377c8a461464748586049afbd9321f51", size = 11369556, upload-time = "2026-03-26T16:26:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/92/4c/6d2f8f34bc6d502ab778c9345a4a936a72ae113de11329c1764bb1f204f6/ty-0.0.26-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:384807bbcb7d7ce9b97ee5aaa6417a8ae03ccfb426c52b08018ca62cf60f5430", size = 11085679, upload-time = "2026-03-26T16:27:21.746Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f4/f3f61c203bc980dd9bba0ba7ed3c6e81ddfd36b286330f9487c2c7d041aa/ty-0.0.26-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a2c766a94d79b4f82995d41229702caf2d76e5c440ec7e543d05c70e98bf8ab", size = 10900581, upload-time = "2026-03-26T16:27:24.39Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/fd/3ca1b4e4bdd129829e9ce78677e0f8e0f1038a7702dccecfa52f037c6046/ty-0.0.26-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f41ac45a0f8e3e8e181508d863a0a62156341db0f624ffd004b97ee550a9de80", size = 10294401, upload-time = "2026-03-26T16:27:03.999Z" },
+    { url = "https://files.pythonhosted.org/packages/de/20/4ee3d8c3f90e008843795c765cb8bb245f188c23e5e5cc612c7697406fba/ty-0.0.26-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:73eb8327a34d529438dfe4db46796946c4e825167cbee434dc148569892e435f", size = 10351469, upload-time = "2026-03-26T16:27:19.003Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b1/9fb154ade65906d4148f0b999c4a8257c2a34253cb72e15d84c1f04a064e/ty-0.0.26-py3-none-musllinux_1_2_i686.whl", hash = "sha256:4bb53a79259516535a1b55f613ba1619e9c666854946474ca8418c35a5c4fd60", size = 10529488, upload-time = "2026-03-26T16:27:01.378Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/70/9b02b03b1862e27b64143db65946d68b138160a5b6bfea193bee0b8bbc34/ty-0.0.26-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2f0e75edc1aeb1b4b84af516c7891f631254a4ca3dcd15e848fa1e061e1fe9da", size = 10999015, upload-time = "2026-03-26T16:27:34.636Z" },
+    { url = "https://files.pythonhosted.org/packages/21/16/0a56b8667296e2989b9d48095472d98ebf57a0006c71f2a101bbc62a142d/ty-0.0.26-py3-none-win32.whl", hash = "sha256:943c998c5523ed6b519c899c0c39b26b4c751a9759e460fb964765a44cde226f", size = 9912378, upload-time = "2026-03-26T16:27:08.999Z" },
+    { url = "https://files.pythonhosted.org/packages/60/c2/fef0d4bba9cd89a82d725b3b1a66efb1b36629ecf0fb1d8e916cb75b8829/ty-0.0.26-py3-none-win_amd64.whl", hash = "sha256:19c856d343efeb1ecad8ee220848f5d2c424daf7b2feda357763ad3036e2172f", size = 10863737, upload-time = "2026-03-26T16:27:27.06Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/05/888ebcb3c4d3b6b72d5d3241fddd299142caa3c516e6d26a9cd887dfed3b/ty-0.0.26-py3-none-win_arm64.whl", hash = "sha256:2cde58ccffa046db1223dc28f3e7d4f2c7da8267e97cc5cd186af6fe85f1758a", size = 10285408, upload-time = "2026-03-26T16:27:16.432Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- **Phase 8A domain model:** `Side` enum, `ExecutionConfig`, `TradeResult`, `PortfolioSnapshot` value objects; `Signal`, `Position`, `Trade`, `EquityCurve` entities; `IStrategy` and `IPositionSizer` protocols
- **Type checker migration:** Replace pyright with Astral's `ty` across CI, pre-commit, and dev dependencies
- Add `# ty: ignore` comments for known third-party typing mismatches (arch, binance, statsmodels, pandas)

## Test plan
- [x] `uv run ty check src/ --exclude src/tests/** --exclude src/app/research/**` passes clean
- [x] All pre-commit hooks pass (`ruff format`, `ruff lint`, `ty`)
- [x] CI lint job passes with new `ty` step
- [x] CI test job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)