### PR TITLE
test(backtest): add comprehensive Phase 8F tests (186 tests)

### DIFF
--- a/src/tests/backtest/__init__.py
+++ b/src/tests/backtest/__init__.py
@@ -1,0 +1,1 @@
+"""Backtest module test package."""

--- a/src/tests/backtest/conftest.py
+++ b/src/tests/backtest/conftest.py
@@ -1,0 +1,249 @@
+"""Shared fixtures and factory functions for backtest module tests.
+
+Provides bar DataFrames, fake strategies, fake position sizers, and
+portfolio snapshot builders used across all backtest test modules.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, UTC
+
+import polars as pl
+import pytest
+
+from src.app.backtest.domain.entities import Signal
+from src.app.backtest.domain.value_objects import ExecutionConfig, PortfolioSnapshot, Side
+from src.app.ohlcv.domain.value_objects import Asset
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_BASE_TS: datetime = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+_ONE_HOUR: timedelta = timedelta(hours=1)
+
+BTC_ASSET: Asset = Asset(symbol="BTCUSDT")
+ETH_ASSET: Asset = Asset(symbol="ETHUSDT")
+
+INITIAL_CASH: float = 100_000.0
+
+
+# ---------------------------------------------------------------------------
+# Bar factory
+# ---------------------------------------------------------------------------
+
+
+def make_bars(
+    n: int,
+    *,
+    start_price: float = 40_000.0,
+    start_time: datetime = _BASE_TS,
+    interval_hours: int = 1,
+    price_step: float = 0.0,
+    volume: float = 10.0,
+) -> pl.DataFrame:
+    """Build a minimal OHLCV Polars DataFrame for backtest tests.
+
+    Args:
+        n: Number of bars to generate.
+        start_price: Open price for the first bar.
+        start_time: Timestamp for the first bar.
+        interval_hours: Hours between consecutive bar timestamps.
+        price_step: Price increment per bar (0 for flat prices).
+        volume: Volume for every bar.
+
+    Returns:
+        DataFrame with columns: timestamp, open, high, low, close, volume.
+    """
+    interval: timedelta = timedelta(hours=interval_hours)
+    timestamps: list[datetime] = [start_time + i * interval for i in range(n)]
+    opens: list[float] = [start_price + i * price_step for i in range(n)]
+    closes: list[float] = [start_price + i * price_step for i in range(n)]
+    highs: list[float] = [p + 200.0 for p in closes]
+    lows: list[float] = [max(1.0, p - 200.0) for p in closes]
+    volumes: list[float] = [volume] * n
+
+    return pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "open": opens,
+            "high": highs,
+            "low": lows,
+            "close": closes,
+            "volume": volumes,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Portfolio snapshot factory
+# ---------------------------------------------------------------------------
+
+
+def make_snapshot(
+    *,
+    equity: float = INITIAL_CASH,
+    cash: float = INITIAL_CASH,
+    timestamp: datetime = _BASE_TS,
+    positions: dict[str, float] | None = None,
+) -> PortfolioSnapshot:
+    """Build a PortfolioSnapshot for test use.
+
+    Args:
+        equity: Total portfolio equity.
+        cash: Available cash balance.
+        timestamp: Snapshot timestamp.
+        positions: Open positions dict (symbol -> signed size).
+
+    Returns:
+        Configured PortfolioSnapshot.
+    """
+    return PortfolioSnapshot(
+        timestamp=timestamp,
+        equity=equity,
+        cash=cash,
+        positions=positions or {},
+        unrealized_pnl=0.0,
+        drawdown=0.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fake strategies
+# ---------------------------------------------------------------------------
+
+
+class AlwaysLongStrategy:
+    """Fake strategy that emits a LONG signal on every bar without an open position.
+
+    Checks ``portfolio.positions`` to avoid re-entering when already long,
+    which would cause the engine to overwrite the existing position and create
+    a Trade with entry_time == exit_time on the last bar.
+    """
+
+    def __init__(self, asset: Asset) -> None:
+        self._asset: Asset = asset
+
+    def on_bar(
+        self,
+        timestamp: datetime,
+        features: pl.DataFrame,  # noqa: ARG002
+        portfolio: PortfolioSnapshot,
+    ) -> list[Signal]:
+        if len(portfolio.positions) > 0:
+            return []
+        return [
+            Signal(
+                asset=self._asset,
+                side=Side.LONG,
+                strength=1.0,
+                timestamp=timestamp,
+            )
+        ]
+
+
+class NeverTradeStrategy:
+    """Fake strategy that never emits any signals."""
+
+    def on_bar(
+        self,
+        timestamp: datetime,  # noqa: ARG002
+        features: pl.DataFrame,  # noqa: ARG002
+        portfolio: PortfolioSnapshot,  # noqa: ARG002
+    ) -> list[Signal]:
+        return []
+
+
+class SingleSignalStrategy:
+    """Fake strategy that emits one signal at bar index 0 only."""
+
+    def __init__(self, asset: Asset, side: Side = Side.LONG) -> None:
+        self._asset: Asset = asset
+        self._side: Side = side
+        self._call_count: int = 0
+
+    def on_bar(
+        self,
+        timestamp: datetime,
+        features: pl.DataFrame,  # noqa: ARG002
+        portfolio: PortfolioSnapshot,  # noqa: ARG002
+    ) -> list[Signal]:
+        self._call_count += 1
+        if self._call_count == 1:
+            return [
+                Signal(
+                    asset=self._asset,
+                    side=self._side,
+                    strength=1.0,
+                    timestamp=timestamp,
+                )
+            ]
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Fake position sizer
+# ---------------------------------------------------------------------------
+
+
+class FixedNotionalSizer:
+    """Fake sizer that returns a fixed notional regardless of portfolio state."""
+
+    def __init__(self, notional: float = 10_000.0) -> None:
+        self._notional: float = notional
+
+    def size(
+        self,
+        signal: Signal,  # noqa: ARG002
+        portfolio: PortfolioSnapshot,  # noqa: ARG002
+        volatility: float,  # noqa: ARG002
+    ) -> float:
+        return self._notional
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def btc_asset() -> Asset:
+    """Return a BTCUSDT asset."""
+    return BTC_ASSET
+
+
+@pytest.fixture
+def eth_asset() -> Asset:
+    """Return an ETHUSDT asset."""
+    return ETH_ASSET
+
+
+@pytest.fixture
+def default_config() -> ExecutionConfig:
+    """Return a default ExecutionConfig with 10 bps commission."""
+    return ExecutionConfig(commission_bps=10.0)
+
+
+@pytest.fixture
+def zero_commission_config() -> ExecutionConfig:
+    """Return an ExecutionConfig with zero commission."""
+    return ExecutionConfig(commission_bps=0.0)
+
+
+@pytest.fixture
+def flat_bars_5() -> pl.DataFrame:
+    """Return 5 flat-price bars at 40_000 each."""
+    return make_bars(5, start_price=40_000.0)
+
+
+@pytest.fixture
+def rising_bars_10() -> pl.DataFrame:
+    """Return 10 bars with price increasing by 100 per bar."""
+    return make_bars(10, start_price=40_000.0, price_step=100.0)
+
+
+@pytest.fixture
+def default_snapshot() -> PortfolioSnapshot:
+    """Return a default portfolio snapshot with 100_000 cash/equity."""
+    return make_snapshot()

--- a/src/tests/backtest/test_baselines.py
+++ b/src/tests/backtest/test_baselines.py
@@ -1,0 +1,234 @@
+"""Unit tests for BuyAndHoldStrategy and RandomStrategy baselines."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, UTC
+
+import polars as pl
+import pytest
+
+from src.app.backtest.application.baselines import BuyAndHoldStrategy, RandomStrategy
+from src.app.backtest.application.execution import BacktestResult, ExecutionEngine
+from src.app.backtest.application.position_sizer import FixedFractionalSizer
+from src.app.backtest.domain.entities import Signal
+from src.app.backtest.domain.value_objects import ExecutionConfig, PortfolioSnapshot, Side
+from src.app.ohlcv.domain.value_objects import Asset
+from src.tests.backtest.conftest import INITIAL_CASH, make_bars, make_snapshot
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_T0: datetime = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+_ONE_HOUR: timedelta = timedelta(hours=1)
+_BTC: Asset = Asset(symbol="BTCUSDT")
+_ETH: Asset = Asset(symbol="ETHUSDT")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_empty_features() -> pl.DataFrame:
+    """Return an empty DataFrame as a stand-in for features."""
+    return pl.DataFrame()
+
+
+def _make_portfolio(*, has_position: bool = False) -> PortfolioSnapshot:
+    """Build a PortfolioSnapshot with or without an open position."""
+    positions: dict[str, float] = {"BTCUSDT": 0.1} if has_position else {}
+    return make_snapshot(positions=positions)
+
+
+# ---------------------------------------------------------------------------
+# TestBuyAndHoldStrategy
+# ---------------------------------------------------------------------------
+
+
+class TestBuyAndHoldStrategy:
+    """Tests for BuyAndHoldStrategy."""
+
+    def test_first_bar_with_no_position_emits_signal(self) -> None:
+        """Strategy emits a LONG signal when no position is held."""
+        strategy: BuyAndHoldStrategy = BuyAndHoldStrategy(asset=_BTC)
+        portfolio: PortfolioSnapshot = _make_portfolio(has_position=False)
+        signals: list[Signal] = strategy.on_bar(_T0, _make_empty_features(), portfolio)
+        assert len(signals) == 1
+        assert signals[0].side == Side.LONG
+
+    def test_signal_strength_is_full_conviction(self) -> None:
+        """The LONG signal has strength == 1.0 (full conviction)."""
+        strategy: BuyAndHoldStrategy = BuyAndHoldStrategy(asset=_BTC)
+        portfolio: PortfolioSnapshot = _make_portfolio(has_position=False)
+        signals: list[Signal] = strategy.on_bar(_T0, _make_empty_features(), portfolio)
+        assert signals[0].strength == pytest.approx(1.0)
+
+    def test_signal_asset_matches_strategy_asset(self) -> None:
+        """Emitted signal's asset matches the strategy's configured asset."""
+        strategy: BuyAndHoldStrategy = BuyAndHoldStrategy(asset=_ETH)
+        portfolio: PortfolioSnapshot = _make_portfolio(has_position=False)
+        signals: list[Signal] = strategy.on_bar(_T0, _make_empty_features(), portfolio)
+        assert signals[0].asset == _ETH
+
+    def test_subsequent_bars_emit_no_signal_when_position_held(self) -> None:
+        """Strategy emits no signal when a position is already open."""
+        strategy: BuyAndHoldStrategy = BuyAndHoldStrategy(asset=_BTC)
+        portfolio_with_pos: PortfolioSnapshot = _make_portfolio(has_position=True)
+        signals: list[Signal] = strategy.on_bar(_T0, _make_empty_features(), portfolio_with_pos)
+        assert len(signals) == 0
+
+    def test_only_emits_on_first_bar_in_engine_run(self) -> None:
+        """In a full engine run, BuyAndHold emits exactly one trade signal."""
+        n_bars: int = 10
+        bars: pl.DataFrame = make_bars(n_bars, start_price=40_000.0)
+        strategy: BuyAndHoldStrategy = BuyAndHoldStrategy(asset=_BTC)
+        sizer: FixedFractionalSizer = FixedFractionalSizer(fraction=0.1)
+        config: ExecutionConfig = ExecutionConfig(commission_bps=0.0)
+        engine: ExecutionEngine = ExecutionEngine(config=config, strategy=strategy, sizer=sizer)
+        result: BacktestResult = engine.run(bars=bars, asset=_BTC, initial_cash=INITIAL_CASH)
+        # Buy-and-hold opens position on bar[1] (fill) and holds; liquidates at last bar
+        # → 1 completed trade
+        assert len(result.trades) == 1
+
+    def test_buy_and_hold_equity_rises_on_uptrend(self) -> None:
+        """Buy-and-hold equity increases when prices trend upward (no commission)."""
+        n_bars: int = 10
+        bars: pl.DataFrame = make_bars(n_bars, start_price=40_000.0, price_step=200.0)
+        strategy: BuyAndHoldStrategy = BuyAndHoldStrategy(asset=_BTC)
+        sizer: FixedFractionalSizer = FixedFractionalSizer(fraction=0.5)
+        config: ExecutionConfig = ExecutionConfig(commission_bps=0.0)
+        engine: ExecutionEngine = ExecutionEngine(config=config, strategy=strategy, sizer=sizer)
+        result: BacktestResult = engine.run(bars=bars, asset=_BTC, initial_cash=INITIAL_CASH)
+        final_equity: float = result.equity_curve.values[-1]
+        assert final_equity > INITIAL_CASH
+
+    def test_buy_and_hold_is_frozen_model(self) -> None:
+        """BuyAndHoldStrategy is a frozen Pydantic model."""
+        from pydantic import ValidationError
+
+        strategy: BuyAndHoldStrategy = BuyAndHoldStrategy(asset=_BTC)
+        with pytest.raises(ValidationError):
+            strategy.asset = _ETH  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# TestRandomStrategy
+# ---------------------------------------------------------------------------
+
+
+class TestRandomStrategy:
+    """Tests for RandomStrategy."""
+
+    def test_seed_reproducibility(self) -> None:
+        """Same seed produces the same signal sequence."""
+        n_bars: int = 50
+        bars: pl.DataFrame = make_bars(n_bars)
+
+        strategy_a: RandomStrategy = RandomStrategy(asset=_BTC, signal_frequency=0.3, seed=42)
+        strategy_b: RandomStrategy = RandomStrategy(asset=_BTC, signal_frequency=0.3, seed=42)
+        portfolio: PortfolioSnapshot = make_snapshot()
+        signals_a: list[list[Signal]] = [
+            strategy_a.on_bar(bars["timestamp"][i], bars, portfolio) for i in range(n_bars)
+        ]
+        signals_b: list[list[Signal]] = [
+            strategy_b.on_bar(bars["timestamp"][i], bars, portfolio) for i in range(n_bars)
+        ]
+        # Signal counts must be identical
+        counts_a: list[int] = [len(s) for s in signals_a]
+        counts_b: list[int] = [len(s) for s in signals_b]
+        assert counts_a == counts_b
+
+    def test_different_seeds_produce_different_sequences(self) -> None:
+        """Different seeds produce different signal sequences (with high probability)."""
+        n_bars: int = 100
+        bars: pl.DataFrame = make_bars(n_bars)
+        portfolio: PortfolioSnapshot = make_snapshot()
+
+        strategy_a: RandomStrategy = RandomStrategy(asset=_BTC, signal_frequency=0.3, seed=1)
+        strategy_b: RandomStrategy = RandomStrategy(asset=_BTC, signal_frequency=0.3, seed=999)
+        sides_a: list[Side | None] = []
+        sides_b: list[Side | None] = []
+        for i in range(n_bars):
+            ts: datetime = bars["timestamp"][i]
+            sigs_a: list[Signal] = strategy_a.on_bar(ts, bars, portfolio)
+            sigs_b: list[Signal] = strategy_b.on_bar(ts, bars, portfolio)
+            sides_a.append(sigs_a[0].side if sigs_a else None)
+            sides_b.append(sigs_b[0].side if sigs_b else None)
+        # At least some difference expected with overwhelming probability
+        assert sides_a != sides_b
+
+    def test_frequency_zero_never_emits(self) -> None:
+        """signal_frequency == 0.0 never emits a signal."""
+        n_bars: int = 50
+        bars: pl.DataFrame = make_bars(n_bars)
+        strategy: RandomStrategy = RandomStrategy(asset=_BTC, signal_frequency=0.0, seed=0)
+        portfolio: PortfolioSnapshot = make_snapshot()
+        for i in range(n_bars):
+            signals: list[Signal] = strategy.on_bar(bars["timestamp"][i], bars, portfolio)
+            assert len(signals) == 0
+
+    def test_frequency_one_always_emits(self) -> None:
+        """signal_frequency == 1.0 emits a signal on every bar."""
+        n_bars: int = 50
+        bars: pl.DataFrame = make_bars(n_bars)
+        strategy: RandomStrategy = RandomStrategy(asset=_BTC, signal_frequency=1.0, seed=0)
+        portfolio: PortfolioSnapshot = make_snapshot()
+        for i in range(n_bars):
+            signals: list[Signal] = strategy.on_bar(bars["timestamp"][i], bars, portfolio)
+            assert len(signals) == 1
+
+    def test_signal_frequency_preserved_approximately(self) -> None:
+        """Observed signal rate is close to the configured signal_frequency."""
+        n_bars: int = 1_000
+        freq: float = 0.2
+        bars: pl.DataFrame = make_bars(n_bars)
+        strategy: RandomStrategy = RandomStrategy(asset=_BTC, signal_frequency=freq, seed=7)
+        portfolio: PortfolioSnapshot = make_snapshot()
+        total_signals: int = 0
+        for i in range(n_bars):
+            signals: list[Signal] = strategy.on_bar(bars["timestamp"][i], bars, portfolio)
+            total_signals += len(signals)
+        observed_rate: float = total_signals / n_bars
+        # Allow ±5% tolerance
+        assert observed_rate == pytest.approx(freq, abs=0.05)
+
+    def test_random_strategy_emits_both_sides(self) -> None:
+        """RandomStrategy emits both LONG and SHORT signals over many bars."""
+        n_bars: int = 500
+        bars: pl.DataFrame = make_bars(n_bars)
+        strategy: RandomStrategy = RandomStrategy(asset=_BTC, signal_frequency=1.0, seed=21)
+        portfolio: PortfolioSnapshot = make_snapshot()
+        sides: set[Side] = set()
+        for i in range(n_bars):
+            signals: list[Signal] = strategy.on_bar(bars["timestamp"][i], bars, portfolio)
+            for sig in signals:
+                sides.add(sig.side)
+        assert Side.LONG in sides
+        assert Side.SHORT in sides
+
+    def test_random_strategy_signal_has_full_strength(self) -> None:
+        """Emitted signals always have strength == 1.0."""
+        n_bars: int = 50
+        bars: pl.DataFrame = make_bars(n_bars)
+        strategy: RandomStrategy = RandomStrategy(asset=_BTC, signal_frequency=1.0, seed=5)
+        portfolio: PortfolioSnapshot = make_snapshot()
+        for i in range(n_bars):
+            signals: list[Signal] = strategy.on_bar(bars["timestamp"][i], bars, portfolio)
+            for sig in signals:
+                assert sig.strength == pytest.approx(1.0)
+
+    def test_invalid_frequency_raises(self) -> None:
+        """signal_frequency > 1.0 raises ValidationError."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            RandomStrategy(asset=_BTC, signal_frequency=1.5)
+
+    def test_negative_frequency_raises(self) -> None:
+        """signal_frequency < 0.0 raises ValidationError."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            RandomStrategy(asset=_BTC, signal_frequency=-0.1)

--- a/src/tests/backtest/test_cost_sweep.py
+++ b/src/tests/backtest/test_cost_sweep.py
@@ -1,0 +1,278 @@
+"""Tests for cost-sensitivity sweep across multiple commission levels."""
+
+from __future__ import annotations
+
+from datetime import datetime, UTC
+
+import pytest
+
+from src.app.backtest.application.cost_sweep import run_with_cost_sweep
+from src.app.backtest.application.execution import BacktestResult, ExecutionEngine
+from src.app.backtest.domain.value_objects import ExecutionConfig, Side
+from src.app.ohlcv.domain.value_objects import Asset
+from src.tests.backtest.conftest import (
+    INITIAL_CASH,
+    AlwaysLongStrategy,
+    FixedNotionalSizer,
+    NeverTradeStrategy,
+    SingleSignalStrategy,
+    make_bars,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_T0: datetime = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+_BTC: Asset = Asset(symbol="BTCUSDT")
+
+_FEE_LEVELS: list[float] = [5.0, 10.0, 15.0, 20.0, 30.0]
+
+
+# ---------------------------------------------------------------------------
+# TestRunWithCostSweep — result structure
+# ---------------------------------------------------------------------------
+
+
+class TestCostSweepResultStructure:
+    """Tests verifying the structure of cost-sweep results."""
+
+    def test_returns_dict_keyed_by_fee_level(self) -> None:
+        """run_with_cost_sweep returns a dict with fee levels as keys."""
+        bars = make_bars(5, start_price=40_000.0)
+        fees: list[float] = [5.0, 10.0, 20.0]
+        results: dict[float, BacktestResult] = run_with_cost_sweep(
+            strategy=NeverTradeStrategy(),
+            sizer=FixedNotionalSizer(),
+            bars=bars,
+            asset=_BTC,
+            fees=fees,
+        )
+        assert set(results.keys()) == {5.0, 10.0, 20.0}
+
+    def test_result_count_matches_fee_levels(self) -> None:
+        """Number of results equals the number of fee levels."""
+        bars = make_bars(5, start_price=40_000.0)
+        fees: list[float] = [5.0, 10.0, 15.0, 20.0, 30.0]
+        results: dict[float, BacktestResult] = run_with_cost_sweep(
+            strategy=NeverTradeStrategy(),
+            sizer=FixedNotionalSizer(),
+            bars=bars,
+            asset=_BTC,
+            fees=fees,
+        )
+        assert len(results) == len(fees)
+
+    def test_each_result_is_backtest_result(self) -> None:
+        """Every value in the returned dict is a BacktestResult."""
+        bars = make_bars(5, start_price=40_000.0)
+        results: dict[float, BacktestResult] = run_with_cost_sweep(
+            strategy=NeverTradeStrategy(),
+            sizer=FixedNotionalSizer(),
+            bars=bars,
+            asset=_BTC,
+            fees=[10.0],
+        )
+        for result in results.values():
+            assert isinstance(result, BacktestResult)
+
+    def test_config_commission_matches_fee_level(self) -> None:
+        """Each result's config.commission_bps matches the corresponding fee level."""
+        bars = make_bars(5, start_price=40_000.0)
+        fees: list[float] = [5.0, 15.0, 25.0]
+        results: dict[float, BacktestResult] = run_with_cost_sweep(
+            strategy=NeverTradeStrategy(),
+            sizer=FixedNotionalSizer(),
+            bars=bars,
+            asset=_BTC,
+            fees=fees,
+        )
+        for fee in fees:
+            assert results[fee].config.commission_bps == pytest.approx(fee)
+
+    def test_default_fees_when_none(self) -> None:
+        """Passing fees=None uses the default 5-level sweep."""
+        bars = make_bars(5, start_price=40_000.0)
+        results: dict[float, BacktestResult] = run_with_cost_sweep(
+            strategy=NeverTradeStrategy(),
+            sizer=FixedNotionalSizer(),
+            bars=bars,
+            asset=_BTC,
+            fees=None,
+        )
+        assert len(results) == 5
+
+
+# ---------------------------------------------------------------------------
+# TestCostSweepEconomics — higher fees reduce final equity
+# ---------------------------------------------------------------------------
+
+
+class TestCostSweepEconomics:
+    """Tests verifying that higher fees produce lower final equity."""
+
+    def test_higher_fee_lowers_final_equity(self) -> None:
+        """With active trading, higher commission results in lower final equity.
+
+        Each fee-level run gets its own strategy instance (AlwaysLongStrategy is
+        stateless) so all runs see identical signal sequences.
+        """
+        # 5 bars so position opens at bar[1] and is liquidated at bar[4] (different time)
+        bars = make_bars(5, start_price=40_000.0)
+        fees: list[float] = [5.0, 10.0, 20.0]
+        # run_with_cost_sweep shares a single strategy instance; use AlwaysLongStrategy
+        # which has no per-call state so each run behaves identically
+        equities: list[float] = []
+        for fee in sorted(fees):
+            config: ExecutionConfig = ExecutionConfig(commission_bps=fee)
+            engine: ExecutionEngine = ExecutionEngine(
+                config=config,
+                strategy=AlwaysLongStrategy(_BTC),
+                sizer=FixedNotionalSizer(notional=10_000.0),
+            )
+            result: BacktestResult = engine.run(bars=bars, asset=_BTC, initial_cash=INITIAL_CASH)
+            equities.append(result.equity_curve.values[-1])
+        # Each step should be non-increasing
+        assert equities[0] >= equities[1] >= equities[2]
+
+    def test_zero_commission_highest_equity(self) -> None:
+        """Zero commission result has the highest final equity among all fee levels."""
+        bars = make_bars(5, start_price=40_000.0, price_step=100.0)
+        fees: list[float] = [0.0, 5.0, 10.0, 20.0]
+        results: dict[float, BacktestResult] = run_with_cost_sweep(
+            strategy=SingleSignalStrategy(_BTC, Side.LONG),
+            sizer=FixedNotionalSizer(notional=10_000.0),
+            bars=bars,
+            asset=_BTC,
+            fees=fees,
+            initial_cash=INITIAL_CASH,
+        )
+        zero_equity: float = results[0.0].equity_curve.values[-1]
+        for fee in [5.0, 10.0, 20.0]:
+            assert zero_equity >= results[fee].equity_curve.values[-1]
+
+    def test_no_trades_equity_identical_across_fees(self) -> None:
+        """With no trades, final equity is the same regardless of fee level."""
+        bars = make_bars(5, start_price=40_000.0)
+        fees: list[float] = [5.0, 10.0, 30.0]
+        results: dict[float, BacktestResult] = run_with_cost_sweep(
+            strategy=NeverTradeStrategy(),
+            sizer=FixedNotionalSizer(),
+            bars=bars,
+            asset=_BTC,
+            fees=fees,
+            initial_cash=INITIAL_CASH,
+        )
+        equities: list[float] = [results[fee].equity_curve.values[-1] for fee in fees]
+        for eq in equities:
+            assert eq == pytest.approx(equities[0])
+
+
+# ---------------------------------------------------------------------------
+# TestCostSweepBaseConfig — inheritance from base_config
+# ---------------------------------------------------------------------------
+
+
+class TestCostSweepBaseConfig:
+    """Tests for base_config inheritance in cost sweeps."""
+
+    def test_base_config_min_trade_count_inherited(self) -> None:
+        """Base config min_trade_count is preserved in all sweep results."""
+        bars = make_bars(5, start_price=40_000.0)
+        base: ExecutionConfig = ExecutionConfig(commission_bps=10.0, min_trade_count=50)
+        fees: list[float] = [5.0, 15.0]
+        results: dict[float, BacktestResult] = run_with_cost_sweep(
+            strategy=NeverTradeStrategy(),
+            sizer=FixedNotionalSizer(),
+            bars=bars,
+            asset=_BTC,
+            fees=fees,
+            base_config=base,
+        )
+        for result in results.values():
+            assert result.config.min_trade_count == 50
+
+    def test_base_config_asset_multiplier_inherited(self) -> None:
+        """Base config per-asset multiplier is inherited in all sweep results."""
+        bars = make_bars(5, start_price=40_000.0)
+        base: ExecutionConfig = ExecutionConfig(
+            commission_bps=10.0,
+            asset_cost_multiplier={"BTCUSDT": 1.5},
+        )
+        fees: list[float] = [5.0, 10.0]
+        results: dict[float, BacktestResult] = run_with_cost_sweep(
+            strategy=NeverTradeStrategy(),
+            sizer=FixedNotionalSizer(),
+            bars=bars,
+            asset=_BTC,
+            fees=fees,
+            base_config=base,
+        )
+        for result in results.values():
+            assert result.config.asset_cost_multiplier.get("BTCUSDT") == pytest.approx(1.5)
+
+    def test_none_base_config_uses_defaults(self) -> None:
+        """None base_config uses ExecutionConfig defaults."""
+        bars = make_bars(5, start_price=40_000.0)
+        fees: list[float] = [10.0]
+        results: dict[float, BacktestResult] = run_with_cost_sweep(
+            strategy=NeverTradeStrategy(),
+            sizer=FixedNotionalSizer(),
+            bars=bars,
+            asset=_BTC,
+            fees=fees,
+            base_config=None,
+        )
+        assert results[10.0].config.min_trade_count == 30
+
+
+# ---------------------------------------------------------------------------
+# TestCostSweepEdgeCases
+# ---------------------------------------------------------------------------
+
+
+class TestCostSweepEdgeCases:
+    """Edge case tests for cost sweep."""
+
+    def test_single_fee_level_produces_single_result(self) -> None:
+        """A single fee level returns exactly one result."""
+        bars = make_bars(5, start_price=40_000.0)
+        results: dict[float, BacktestResult] = run_with_cost_sweep(
+            strategy=NeverTradeStrategy(),
+            sizer=FixedNotionalSizer(),
+            bars=bars,
+            asset=_BTC,
+            fees=[7.5],
+        )
+        assert len(results) == 1
+        assert 7.5 in results
+
+    def test_equity_curve_present_in_all_results(self) -> None:
+        """All sweep results have an equity curve with correct length."""
+        n_bars: int = 8
+        bars = make_bars(n_bars, start_price=40_000.0)
+        results: dict[float, BacktestResult] = run_with_cost_sweep(
+            strategy=NeverTradeStrategy(),
+            sizer=FixedNotionalSizer(),
+            bars=bars,
+            asset=_BTC,
+            fees=[5.0, 10.0],
+        )
+        for result in results.values():
+            assert len(result.equity_curve.values) == n_bars
+
+    def test_initial_cash_propagated_to_all_runs(self) -> None:
+        """Custom initial_cash is used in all fee-level runs."""
+        custom_cash: float = 50_000.0
+        bars = make_bars(5, start_price=40_000.0)
+        results: dict[float, BacktestResult] = run_with_cost_sweep(
+            strategy=NeverTradeStrategy(),
+            sizer=FixedNotionalSizer(),
+            bars=bars,
+            asset=_BTC,
+            fees=[5.0, 10.0],
+            initial_cash=custom_cash,
+        )
+        for result in results.values():
+            assert result.equity_curve.values[0] == pytest.approx(custom_cash)

--- a/src/tests/backtest/test_domain.py
+++ b/src/tests/backtest/test_domain.py
@@ -1,0 +1,580 @@
+"""Unit tests for backtest domain value objects and entities."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, UTC
+
+import pytest
+from pydantic import ValidationError
+
+from src.app.backtest.domain.entities import EquityCurve, Position, Signal, Trade
+from src.app.backtest.domain.value_objects import (
+    ExecutionConfig,
+    PortfolioSnapshot,
+    Side,
+    TradeResult,
+)
+from src.app.ohlcv.domain.value_objects import Asset
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_T0: datetime = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+_T1: datetime = datetime(2024, 1, 1, 1, 0, 0, tzinfo=UTC)
+_T2: datetime = datetime(2024, 1, 1, 2, 0, 0, tzinfo=UTC)
+_T3: datetime = datetime(2024, 1, 1, 3, 0, 0, tzinfo=UTC)
+
+_BTC: Asset = Asset(symbol="BTCUSDT")
+
+
+# ---------------------------------------------------------------------------
+# Side
+# ---------------------------------------------------------------------------
+
+
+class TestSide:
+    """Tests for the Side enum."""
+
+    def test_long_value(self) -> None:
+        """Side.LONG has value 'long'."""
+        assert Side.LONG == "long"
+
+    def test_short_value(self) -> None:
+        """Side.SHORT has value 'short'."""
+        assert Side.SHORT == "short"
+
+    def test_side_is_str_enum(self) -> None:
+        """Side inherits from str so it can be compared directly to strings."""
+        assert isinstance(Side.LONG, str)
+
+
+# ---------------------------------------------------------------------------
+# ExecutionConfig
+# ---------------------------------------------------------------------------
+
+
+class TestExecutionConfig:
+    """Tests for ExecutionConfig validation and defaults."""
+
+    def test_default_commission_bps(self) -> None:
+        """Default commission is 10 bps."""
+        config: ExecutionConfig = ExecutionConfig()
+        assert config.commission_bps == pytest.approx(10.0)
+
+    def test_custom_commission_bps(self) -> None:
+        """Custom commission bps is stored correctly."""
+        config: ExecutionConfig = ExecutionConfig(commission_bps=5.0)
+        assert config.commission_bps == pytest.approx(5.0)
+
+    def test_zero_commission_bps_allowed(self) -> None:
+        """Commission of 0 bps is valid."""
+        config: ExecutionConfig = ExecutionConfig(commission_bps=0.0)
+        assert config.commission_bps == pytest.approx(0.0)
+
+    def test_negative_commission_raises(self) -> None:
+        """Negative commission bps raises ValidationError."""
+        with pytest.raises(ValidationError):
+            ExecutionConfig(commission_bps=-1.0)
+
+    def test_default_cost_sweep_bps(self) -> None:
+        """Default cost sweep has 5 levels."""
+        config: ExecutionConfig = ExecutionConfig()
+        assert len(config.cost_sweep_bps) == 5
+
+    def test_asset_cost_multiplier_defaults_empty(self) -> None:
+        """asset_cost_multiplier defaults to empty dict."""
+        config: ExecutionConfig = ExecutionConfig()
+        assert config.asset_cost_multiplier == {}
+
+    def test_per_asset_multiplier_stored(self) -> None:
+        """Per-asset cost multiplier is stored and retrievable."""
+        config: ExecutionConfig = ExecutionConfig(asset_cost_multiplier={"BTCUSDT": 1.5})
+        assert config.asset_cost_multiplier["BTCUSDT"] == pytest.approx(1.5)
+
+    def test_min_trade_count_must_be_positive(self) -> None:
+        """min_trade_count <= 0 raises ValidationError."""
+        with pytest.raises(ValidationError):
+            ExecutionConfig(min_trade_count=0)
+
+    def test_frozen_immutability(self) -> None:
+        """ExecutionConfig is frozen — assignment raises."""
+        config: ExecutionConfig = ExecutionConfig()
+        with pytest.raises(ValidationError):
+            config.commission_bps = 99.0  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# TradeResult
+# ---------------------------------------------------------------------------
+
+
+class TestTradeResult:
+    """Tests for TradeResult value object."""
+
+    def test_valid_trade_result(self) -> None:
+        """TradeResult with valid fields is created correctly."""
+        tr: TradeResult = TradeResult(
+            entry_price=40_000.0,
+            exit_price=41_000.0,
+            side=Side.LONG,
+            size=0.25,
+            entry_time=_T0,
+            exit_time=_T1,
+            gross_pnl=250.0,
+            net_pnl=240.0,
+            commission_paid=10.0,
+        )
+        assert tr.gross_pnl == pytest.approx(250.0)
+        assert tr.net_pnl == pytest.approx(240.0)
+
+    def test_exit_before_entry_raises(self) -> None:
+        """exit_time <= entry_time raises ValueError via model_validator."""
+        with pytest.raises(ValidationError):
+            TradeResult(
+                entry_price=40_000.0,
+                exit_price=41_000.0,
+                side=Side.LONG,
+                size=0.25,
+                entry_time=_T1,
+                exit_time=_T0,
+                gross_pnl=250.0,
+                net_pnl=240.0,
+                commission_paid=10.0,
+            )
+
+    def test_equal_entry_exit_time_raises(self) -> None:
+        """exit_time == entry_time (not strictly after) raises ValueError."""
+        with pytest.raises(ValidationError):
+            TradeResult(
+                entry_price=40_000.0,
+                exit_price=41_000.0,
+                side=Side.LONG,
+                size=0.25,
+                entry_time=_T0,
+                exit_time=_T0,
+                gross_pnl=0.0,
+                net_pnl=0.0,
+                commission_paid=0.0,
+            )
+
+    def test_negative_entry_price_raises(self) -> None:
+        """Negative entry_price raises ValidationError."""
+        with pytest.raises(ValidationError):
+            TradeResult(
+                entry_price=-1.0,
+                exit_price=41_000.0,
+                side=Side.LONG,
+                size=0.25,
+                entry_time=_T0,
+                exit_time=_T1,
+                gross_pnl=0.0,
+                net_pnl=0.0,
+                commission_paid=0.0,
+            )
+
+    def test_zero_size_raises(self) -> None:
+        """size == 0 raises ValidationError (must be > 0)."""
+        with pytest.raises(ValidationError):
+            TradeResult(
+                entry_price=40_000.0,
+                exit_price=41_000.0,
+                side=Side.LONG,
+                size=0.0,
+                entry_time=_T0,
+                exit_time=_T1,
+                gross_pnl=0.0,
+                net_pnl=0.0,
+                commission_paid=0.0,
+            )
+
+    def test_negative_commission_raises(self) -> None:
+        """Negative commission_paid raises ValidationError."""
+        with pytest.raises(ValidationError):
+            TradeResult(
+                entry_price=40_000.0,
+                exit_price=41_000.0,
+                side=Side.LONG,
+                size=0.25,
+                entry_time=_T0,
+                exit_time=_T1,
+                gross_pnl=0.0,
+                net_pnl=0.0,
+                commission_paid=-1.0,
+            )
+
+
+# ---------------------------------------------------------------------------
+# PortfolioSnapshot
+# ---------------------------------------------------------------------------
+
+
+class TestPortfolioSnapshot:
+    """Tests for PortfolioSnapshot value object."""
+
+    def test_valid_snapshot(self) -> None:
+        """Valid snapshot is created without error."""
+        snap: PortfolioSnapshot = PortfolioSnapshot(
+            timestamp=_T0,
+            equity=100_000.0,
+            cash=100_000.0,
+        )
+        assert snap.equity == pytest.approx(100_000.0)
+
+    def test_negative_equity_raises(self) -> None:
+        """Negative equity raises ValidationError."""
+        with pytest.raises(ValidationError):
+            PortfolioSnapshot(
+                timestamp=_T0,
+                equity=-1.0,
+                cash=100_000.0,
+            )
+
+    def test_positive_drawdown_raises(self) -> None:
+        """Positive drawdown raises ValidationError (must be <= 0)."""
+        with pytest.raises(ValidationError):
+            PortfolioSnapshot(
+                timestamp=_T0,
+                equity=100_000.0,
+                cash=100_000.0,
+                drawdown=0.05,
+            )
+
+    def test_drawdown_zero_is_valid(self) -> None:
+        """drawdown == 0.0 is valid."""
+        snap: PortfolioSnapshot = PortfolioSnapshot(
+            timestamp=_T0,
+            equity=100_000.0,
+            cash=100_000.0,
+            drawdown=0.0,
+        )
+        assert snap.drawdown == pytest.approx(0.0)
+
+    def test_positions_default_empty(self) -> None:
+        """positions dict defaults to empty when not supplied."""
+        snap: PortfolioSnapshot = PortfolioSnapshot(
+            timestamp=_T0,
+            equity=100_000.0,
+            cash=100_000.0,
+        )
+        assert snap.positions == {}
+
+
+# ---------------------------------------------------------------------------
+# Signal
+# ---------------------------------------------------------------------------
+
+
+class TestSignal:
+    """Tests for Signal entity."""
+
+    def test_valid_long_signal(self) -> None:
+        """Valid LONG signal is created correctly."""
+        sig: Signal = Signal(
+            asset=_BTC,
+            side=Side.LONG,
+            strength=0.8,
+            timestamp=_T0,
+        )
+        assert sig.side == Side.LONG
+        assert sig.strength == pytest.approx(0.8)
+
+    def test_strength_above_one_raises(self) -> None:
+        """strength > 1.0 raises ValidationError."""
+        with pytest.raises(ValidationError):
+            Signal(
+                asset=_BTC,
+                side=Side.LONG,
+                strength=1.1,
+                timestamp=_T0,
+            )
+
+    def test_strength_below_zero_raises(self) -> None:
+        """strength < 0.0 raises ValidationError."""
+        with pytest.raises(ValidationError):
+            Signal(
+                asset=_BTC,
+                side=Side.LONG,
+                strength=-0.1,
+                timestamp=_T0,
+            )
+
+    def test_strength_exactly_zero_is_valid(self) -> None:
+        """strength == 0.0 is valid (closed interval)."""
+        sig: Signal = Signal(
+            asset=_BTC,
+            side=Side.LONG,
+            strength=0.0,
+            timestamp=_T0,
+        )
+        assert sig.strength == pytest.approx(0.0)
+
+    def test_strength_exactly_one_is_valid(self) -> None:
+        """strength == 1.0 is valid (closed interval)."""
+        sig: Signal = Signal(
+            asset=_BTC,
+            side=Side.SHORT,
+            strength=1.0,
+            timestamp=_T0,
+        )
+        assert sig.strength == pytest.approx(1.0)
+
+    def test_signal_is_frozen(self) -> None:
+        """Signal is frozen — field assignment raises."""
+        sig: Signal = Signal(
+            asset=_BTC,
+            side=Side.LONG,
+            strength=1.0,
+            timestamp=_T0,
+        )
+        with pytest.raises(ValidationError):
+            sig.strength = 0.5  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Position
+# ---------------------------------------------------------------------------
+
+
+class TestPosition:
+    """Tests for Position entity."""
+
+    def test_valid_position_creation(self) -> None:
+        """Valid long position is created correctly."""
+        pos: Position = Position(
+            asset=_BTC,
+            side=Side.LONG,
+            size=0.5,
+            entry_price=40_000.0,
+            entry_time=_T0,
+        )
+        assert pos.size == pytest.approx(0.5)
+        assert pos.unrealized_pnl == pytest.approx(0.0)
+
+    def test_negative_size_raises(self) -> None:
+        """Negative position size raises ValidationError."""
+        with pytest.raises(ValidationError):
+            Position(
+                asset=_BTC,
+                side=Side.LONG,
+                size=-0.5,
+                entry_price=40_000.0,
+                entry_time=_T0,
+            )
+
+    def test_zero_size_raises(self) -> None:
+        """Zero position size raises ValidationError."""
+        with pytest.raises(ValidationError):
+            Position(
+                asset=_BTC,
+                side=Side.LONG,
+                size=0.0,
+                entry_price=40_000.0,
+                entry_time=_T0,
+            )
+
+    def test_negative_entry_price_raises(self) -> None:
+        """Negative entry_price raises ValidationError."""
+        with pytest.raises(ValidationError):
+            Position(
+                asset=_BTC,
+                side=Side.LONG,
+                size=0.5,
+                entry_price=-1.0,
+                entry_time=_T0,
+            )
+
+    def test_position_is_mutable(self) -> None:
+        """Position is mutable — unrealized_pnl can be updated."""
+        pos: Position = Position(
+            asset=_BTC,
+            side=Side.LONG,
+            size=0.5,
+            entry_price=40_000.0,
+            entry_time=_T0,
+        )
+        pos.unrealized_pnl = 500.0
+        assert pos.unrealized_pnl == pytest.approx(500.0)
+
+    def test_optional_stop_loss_default_none(self) -> None:
+        """stop_loss defaults to None."""
+        pos: Position = Position(
+            asset=_BTC,
+            side=Side.LONG,
+            size=0.5,
+            entry_price=40_000.0,
+            entry_time=_T0,
+        )
+        assert pos.stop_loss is None
+
+    def test_optional_take_profit_default_none(self) -> None:
+        """take_profit defaults to None."""
+        pos: Position = Position(
+            asset=_BTC,
+            side=Side.LONG,
+            size=0.5,
+            entry_price=40_000.0,
+            entry_time=_T0,
+        )
+        assert pos.take_profit is None
+
+
+# ---------------------------------------------------------------------------
+# Trade
+# ---------------------------------------------------------------------------
+
+
+class TestTrade:
+    """Tests for Trade entity."""
+
+    def test_valid_trade_creation(self) -> None:
+        """Valid trade is created with correct fields."""
+        trade: Trade = Trade(
+            asset=_BTC,
+            side=Side.LONG,
+            size=0.25,
+            entry_price=40_000.0,
+            exit_price=41_000.0,
+            entry_time=_T0,
+            exit_time=_T1,
+            gross_pnl=250.0,
+            net_pnl=240.0,
+            commission_paid=10.0,
+        )
+        assert trade.gross_pnl == pytest.approx(250.0)
+        assert trade.net_pnl == pytest.approx(240.0)
+
+    def test_exit_before_entry_raises(self) -> None:
+        """exit_time before entry_time raises ValidationError."""
+        with pytest.raises(ValidationError):
+            Trade(
+                asset=_BTC,
+                side=Side.LONG,
+                size=0.25,
+                entry_price=40_000.0,
+                exit_price=41_000.0,
+                entry_time=_T1,
+                exit_time=_T0,
+                gross_pnl=0.0,
+                net_pnl=0.0,
+                commission_paid=0.0,
+            )
+
+    def test_to_result_strips_asset(self) -> None:
+        """to_result() returns a TradeResult without Asset reference."""
+        trade: Trade = Trade(
+            asset=_BTC,
+            side=Side.LONG,
+            size=0.25,
+            entry_price=40_000.0,
+            exit_price=41_000.0,
+            entry_time=_T0,
+            exit_time=_T1,
+            gross_pnl=250.0,
+            net_pnl=240.0,
+            commission_paid=10.0,
+        )
+        result: TradeResult = trade.to_result()
+        assert result.entry_price == pytest.approx(40_000.0)
+        assert result.exit_price == pytest.approx(41_000.0)
+        assert result.gross_pnl == pytest.approx(250.0)
+        assert not hasattr(result, "asset")
+
+    def test_trade_is_frozen(self) -> None:
+        """Trade is frozen — field assignment raises."""
+        trade: Trade = Trade(
+            asset=_BTC,
+            side=Side.LONG,
+            size=0.25,
+            entry_price=40_000.0,
+            exit_price=41_000.0,
+            entry_time=_T0,
+            exit_time=_T1,
+            gross_pnl=250.0,
+            net_pnl=240.0,
+            commission_paid=10.0,
+        )
+        with pytest.raises(ValidationError):
+            trade.gross_pnl = 999.0  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# EquityCurve
+# ---------------------------------------------------------------------------
+
+
+class TestEquityCurve:
+    """Tests for EquityCurve entity validation."""
+
+    def test_valid_equity_curve(self) -> None:
+        """Valid equity curve with aligned, monotone timestamps is created."""
+        ec: EquityCurve = EquityCurve(
+            timestamps=[_T0, _T1, _T2],
+            values=[100_000.0, 101_000.0, 102_000.0],
+        )
+        assert len(ec.timestamps) == 3
+        assert len(ec.values) == 3
+
+    def test_mismatched_lengths_raises(self) -> None:
+        """Mismatched timestamps/values length raises ValidationError."""
+        with pytest.raises(ValidationError):
+            EquityCurve(
+                timestamps=[_T0, _T1],
+                values=[100_000.0],
+            )
+
+    def test_non_monotone_timestamps_raises(self) -> None:
+        """Non-monotone timestamps raise ValidationError."""
+        with pytest.raises(ValidationError):
+            EquityCurve(
+                timestamps=[_T0, _T2, _T1],
+                values=[100_000.0, 102_000.0, 101_000.0],
+            )
+
+    def test_duplicate_timestamps_raises(self) -> None:
+        """Duplicate timestamps (not strictly increasing) raise ValidationError."""
+        with pytest.raises(ValidationError):
+            EquityCurve(
+                timestamps=[_T0, _T0, _T2],
+                values=[100_000.0, 100_000.0, 102_000.0],
+            )
+
+    def test_single_element_curve_is_valid(self) -> None:
+        """Single-element equity curve (no ordering check) is valid."""
+        ec: EquityCurve = EquityCurve(
+            timestamps=[_T0],
+            values=[100_000.0],
+        )
+        assert ec.values[0] == pytest.approx(100_000.0)
+
+    def test_empty_curve_is_valid(self) -> None:
+        """Empty equity curve (zero elements) is valid."""
+        ec: EquityCurve = EquityCurve(timestamps=[], values=[])
+        assert len(ec.timestamps) == 0
+
+    def test_equity_curve_is_frozen(self) -> None:
+        """EquityCurve is frozen — field assignment raises."""
+        ec: EquityCurve = EquityCurve(
+            timestamps=[_T0, _T1],
+            values=[100_000.0, 101_000.0],
+        )
+        with pytest.raises(ValidationError):
+            ec.values = [999.0, 999.0]  # type: ignore[misc]
+
+    def test_values_can_decrease(self) -> None:
+        """Equity values may decrease (drawdowns are valid)."""
+        ec: EquityCurve = EquityCurve(
+            timestamps=[_T0, _T1, _T2],
+            values=[100_000.0, 95_000.0, 98_000.0],
+        )
+        assert ec.values[1] == pytest.approx(95_000.0)
+
+    def test_large_curve_monotone_check(self) -> None:
+        """Large equity curve with all increasing timestamps is accepted."""
+        n: int = 1000
+        base: datetime = datetime(2024, 1, 1, tzinfo=UTC)
+        timestamps: list[datetime] = [base + timedelta(hours=i) for i in range(n)]
+        values: list[float] = [100_000.0 + i for i in range(n)]
+        ec: EquityCurve = EquityCurve(timestamps=timestamps, values=values)
+        assert len(ec.timestamps) == n

--- a/src/tests/backtest/test_execution.py
+++ b/src/tests/backtest/test_execution.py
@@ -1,0 +1,569 @@
+"""Unit and integration tests for the ExecutionEngine."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, UTC
+
+import polars as pl
+import pytest
+
+from src.app.backtest.application.execution import BacktestResult, ExecutionEngine
+from src.app.backtest.application.position_sizer import FixedFractionalSizer
+from src.app.backtest.domain.entities import Position, Signal, Trade
+from src.app.backtest.domain.value_objects import ExecutionConfig, Side
+from src.app.ohlcv.domain.value_objects import Asset
+from src.tests.backtest.conftest import (
+    INITIAL_CASH,
+    FixedNotionalSizer,
+    NeverTradeStrategy,
+    SingleSignalStrategy,
+    make_bars,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_T0: datetime = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+_BTC: Asset = Asset(symbol="BTCUSDT")
+
+_ENTRY_PRICE: float = 40_000.0
+_EXIT_PRICE: float = 41_000.0
+_COMMISSION_BPS: float = 10.0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_engine(
+    strategy: object,
+    sizer: object,
+    commission_bps: float = _COMMISSION_BPS,
+) -> ExecutionEngine:
+    """Build an ExecutionEngine with given strategy and sizer."""
+    config: ExecutionConfig = ExecutionConfig(commission_bps=commission_bps)
+    return ExecutionEngine(config=config, strategy=strategy, sizer=sizer)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# TestEmptyAndInvalidBars
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyAndInvalidBars:
+    """Tests for bar validation before execution."""
+
+    def test_empty_bars_raises(self) -> None:
+        """Empty bars DataFrame raises ValueError."""
+        engine: ExecutionEngine = _make_engine(NeverTradeStrategy(), FixedNotionalSizer())
+        empty: pl.DataFrame = pl.DataFrame(
+            {"timestamp": [], "open": [], "high": [], "low": [], "close": [], "volume": []}
+        ).cast(
+            {
+                "timestamp": pl.Datetime(time_unit="us", time_zone="UTC"),
+                "open": pl.Float64,
+                "high": pl.Float64,
+                "low": pl.Float64,
+                "close": pl.Float64,
+                "volume": pl.Float64,
+            }
+        )
+        with pytest.raises(ValueError, match="empty"):
+            engine.run(bars=empty, asset=_BTC)
+
+    def test_missing_column_raises(self) -> None:
+        """Bars missing a required column raises ValueError."""
+        engine: ExecutionEngine = _make_engine(NeverTradeStrategy(), FixedNotionalSizer())
+        bad_bars: pl.DataFrame = pl.DataFrame(
+            {
+                "timestamp": [_T0],
+                "open": [40_000.0],
+                "high": [40_200.0],
+                # 'low' intentionally missing
+                "close": [40_100.0],
+                "volume": [1.0],
+            }
+        )
+        with pytest.raises(ValueError, match="missing required columns"):
+            engine.run(bars=bad_bars, asset=_BTC)
+
+
+# ---------------------------------------------------------------------------
+# TestFillOnNextOpen
+# ---------------------------------------------------------------------------
+
+
+class TestFillOnNextOpen:
+    """Tests verifying that signals fill at the next bar's open price."""
+
+    def test_signal_at_bar_0_fills_at_bar_1_open(self) -> None:
+        """Signal generated at bar[0] is filled at bar[1].open, not bar[0].close."""
+        bar_0_open: float = 40_000.0
+        bar_1_open: float = 41_000.0
+        bar_2_open: float = 42_000.0
+        bars: pl.DataFrame = pl.DataFrame(
+            {
+                "timestamp": [_T0, _T0 + timedelta(hours=1), _T0 + timedelta(hours=2)],
+                "open": [bar_0_open, bar_1_open, bar_2_open],
+                "high": [40_300.0, 41_300.0, 42_300.0],
+                "low": [39_700.0, 40_700.0, 41_700.0],
+                "close": [40_200.0, 41_200.0, 42_200.0],
+                "volume": [10.0, 10.0, 10.0],
+            }
+        )
+        # Strategy emits signal on bar[0] only
+        strategy: SingleSignalStrategy = SingleSignalStrategy(_BTC, Side.LONG)
+        sizer: FixedNotionalSizer = FixedNotionalSizer(notional=10_000.0)
+        engine: ExecutionEngine = _make_engine(strategy, sizer, commission_bps=0.0)
+        result: BacktestResult = engine.run(bars=bars, asset=_BTC)
+
+        # The position should have been opened at bar_1_open
+        assert len(result.trades) >= 1
+        first_trade: Trade = result.trades[0]
+        assert first_trade.entry_price == pytest.approx(bar_1_open)
+
+    def test_no_lookahead_no_entry_on_bar_0(self) -> None:
+        """On bar[0] there are no pending signals yet, so no fill occurs at bar[0].open."""
+        bars: pl.DataFrame = make_bars(3, start_price=40_000.0)
+        strategy: SingleSignalStrategy = SingleSignalStrategy(_BTC, Side.LONG)
+        sizer: FixedNotionalSizer = FixedNotionalSizer(notional=10_000.0)
+        engine: ExecutionEngine = _make_engine(strategy, sizer, commission_bps=0.0)
+        result: BacktestResult = engine.run(bars=bars, asset=_BTC)
+
+        # Entry must be at bar[1].open = 40_000 (flat price bars)
+        if result.trades:
+            assert result.trades[0].entry_price == pytest.approx(40_000.0)
+
+    def test_equity_curve_length_equals_bar_count(self) -> None:
+        """Equity curve length equals the number of input bars."""
+        n_bars: int = 10
+        bars: pl.DataFrame = make_bars(n_bars, start_price=40_000.0)
+        engine: ExecutionEngine = _make_engine(NeverTradeStrategy(), FixedNotionalSizer())
+        result: BacktestResult = engine.run(bars=bars, asset=_BTC)
+        assert len(result.equity_curve.timestamps) == n_bars
+        assert len(result.equity_curve.values) == n_bars
+
+
+# ---------------------------------------------------------------------------
+# TestCommissionCalculation
+# ---------------------------------------------------------------------------
+
+
+class TestCommissionCalculation:
+    """Tests verifying commission deduction on round-trip trades."""
+
+    def test_commission_formula_on_known_inputs(self) -> None:
+        """Commission equals (entry_price + exit_price) * size * bps / 10_000."""
+        # Three bars: signal on bar[0] → fill at bar[1].open, liquidate at bar[2].close
+        # Using distinct timestamps so entry_time < exit_time for liquidation
+        t1: datetime = _T0 + timedelta(hours=1)
+        t2: datetime = _T0 + timedelta(hours=2)
+        bars: pl.DataFrame = pl.DataFrame(
+            {
+                "timestamp": [_T0, t1, t2],
+                "open": [_ENTRY_PRICE, _ENTRY_PRICE, _ENTRY_PRICE],
+                "high": [_ENTRY_PRICE + 300.0, _ENTRY_PRICE + 300.0, _ENTRY_PRICE + 300.0],
+                "low": [_ENTRY_PRICE - 300.0, _ENTRY_PRICE - 300.0, _ENTRY_PRICE - 300.0],
+                "close": [_ENTRY_PRICE, _ENTRY_PRICE, _EXIT_PRICE],
+                "volume": [10.0, 10.0, 10.0],
+            }
+        )
+        notional: float = 10_000.0
+        strategy: SingleSignalStrategy = SingleSignalStrategy(_BTC, Side.LONG)
+        sizer: FixedNotionalSizer = FixedNotionalSizer(notional=notional)
+        engine: ExecutionEngine = _make_engine(strategy, sizer, commission_bps=_COMMISSION_BPS)
+        result: BacktestResult = engine.run(bars=bars, asset=_BTC)
+
+        assert len(result.trades) == 1
+        trade: Trade = result.trades[0]
+        # Engine fills bar[1].open = _ENTRY_PRICE, exits at bar[2].close = _EXIT_PRICE
+        size: float = notional / trade.entry_price
+        expected_comm: float = (trade.entry_price * size + trade.exit_price * size) * _COMMISSION_BPS / 10_000.0
+        assert trade.commission_paid == pytest.approx(expected_comm, rel=1e-6)
+
+    def test_net_pnl_equals_gross_minus_commission(self) -> None:
+        """net_pnl == gross_pnl - commission_paid for every trade."""
+        # Use 6 bars to ensure entry at bar[1] and liquidation at bar[5] differ in time
+        bars: pl.DataFrame = make_bars(6, start_price=40_000.0, price_step=100.0)
+        strategy: SingleSignalStrategy = SingleSignalStrategy(_BTC, Side.LONG)
+        sizer: FixedNotionalSizer = FixedNotionalSizer(notional=10_000.0)
+        engine: ExecutionEngine = _make_engine(strategy, sizer, commission_bps=10.0)
+        result: BacktestResult = engine.run(bars=bars, asset=_BTC)
+
+        for trade in result.trades:
+            assert trade.net_pnl == pytest.approx(trade.gross_pnl - trade.commission_paid, rel=1e-9)
+
+    def test_zero_commission_net_equals_gross(self) -> None:
+        """With zero commission, net_pnl equals gross_pnl."""
+        bars: pl.DataFrame = make_bars(3, start_price=40_000.0, price_step=100.0)
+        strategy: SingleSignalStrategy = SingleSignalStrategy(_BTC, Side.LONG)
+        sizer: FixedNotionalSizer = FixedNotionalSizer(notional=10_000.0)
+        engine: ExecutionEngine = _make_engine(strategy, sizer, commission_bps=0.0)
+        result: BacktestResult = engine.run(bars=bars, asset=_BTC)
+
+        for trade in result.trades:
+            assert trade.net_pnl == pytest.approx(trade.gross_pnl)
+            assert trade.commission_paid == pytest.approx(0.0)
+
+    def test_commission_deducted_on_round_trip(self) -> None:
+        """Final cash is less than initial cash after a zero-PnL round trip with commission."""
+        # Flat prices so gross PnL = 0; commission > 0
+        bars: pl.DataFrame = make_bars(3, start_price=40_000.0, price_step=0.0)
+        strategy: SingleSignalStrategy = SingleSignalStrategy(_BTC, Side.LONG)
+        sizer: FixedNotionalSizer = FixedNotionalSizer(notional=10_000.0)
+        engine: ExecutionEngine = _make_engine(strategy, sizer, commission_bps=10.0)
+        result: BacktestResult = engine.run(bars=bars, asset=_BTC, initial_cash=INITIAL_CASH)
+
+        final_equity: float = result.equity_curve.values[-1]
+        assert final_equity < INITIAL_CASH
+
+    def test_per_asset_multiplier_scales_commission(self) -> None:
+        """Per-asset cost multiplier doubles commission for that asset."""
+        bars: pl.DataFrame = make_bars(3, start_price=40_000.0)
+        strategy: SingleSignalStrategy = SingleSignalStrategy(_BTC, Side.LONG)
+        sizer: FixedNotionalSizer = FixedNotionalSizer(notional=10_000.0)
+
+        config_normal: ExecutionConfig = ExecutionConfig(commission_bps=10.0)
+        config_double: ExecutionConfig = ExecutionConfig(
+            commission_bps=10.0,
+            asset_cost_multiplier={"BTCUSDT": 2.0},
+        )
+        engine_normal: ExecutionEngine = ExecutionEngine(
+            config=config_normal,
+            strategy=SingleSignalStrategy(_BTC, Side.LONG),
+            sizer=sizer,
+        )
+        engine_double: ExecutionEngine = ExecutionEngine(
+            config=config_double,
+            strategy=strategy,
+            sizer=FixedNotionalSizer(notional=10_000.0),
+        )
+        result_normal: BacktestResult = engine_normal.run(bars=bars, asset=_BTC)
+        result_double: BacktestResult = engine_double.run(bars=bars, asset=_BTC)
+
+        if result_normal.trades and result_double.trades:
+            assert result_double.trades[0].commission_paid == pytest.approx(
+                result_normal.trades[0].commission_paid * 2.0, rel=1e-6
+            )
+
+
+# ---------------------------------------------------------------------------
+# TestLongShortPnL
+# ---------------------------------------------------------------------------
+
+
+class TestLongShortPnL:
+    """Tests for correct PnL calculation on long and short positions."""
+
+    def test_long_rising_price_produces_positive_gross_pnl(self) -> None:
+        """LONG position on rising prices yields positive gross PnL."""
+        bars: pl.DataFrame = make_bars(3, start_price=40_000.0, price_step=500.0)
+        strategy: SingleSignalStrategy = SingleSignalStrategy(_BTC, Side.LONG)
+        sizer: FixedNotionalSizer = FixedNotionalSizer(notional=10_000.0)
+        engine: ExecutionEngine = _make_engine(strategy, sizer, commission_bps=0.0)
+        result: BacktestResult = engine.run(bars=bars, asset=_BTC)
+
+        assert len(result.trades) == 1
+        assert result.trades[0].gross_pnl > 0.0
+
+    def test_long_falling_price_produces_negative_gross_pnl(self) -> None:
+        """LONG position on falling prices yields negative gross PnL."""
+        bars: pl.DataFrame = make_bars(3, start_price=40_000.0, price_step=-500.0)
+        strategy: SingleSignalStrategy = SingleSignalStrategy(_BTC, Side.LONG)
+        sizer: FixedNotionalSizer = FixedNotionalSizer(notional=10_000.0)
+        engine: ExecutionEngine = _make_engine(strategy, sizer, commission_bps=0.0)
+        result: BacktestResult = engine.run(bars=bars, asset=_BTC)
+
+        assert len(result.trades) == 1
+        assert result.trades[0].gross_pnl < 0.0
+
+    def test_short_falling_price_produces_positive_gross_pnl(self) -> None:
+        """SHORT position on falling prices yields positive gross PnL."""
+        bars: pl.DataFrame = make_bars(3, start_price=40_000.0, price_step=-500.0)
+        strategy: SingleSignalStrategy = SingleSignalStrategy(_BTC, Side.SHORT)
+        sizer: FixedNotionalSizer = FixedNotionalSizer(notional=10_000.0)
+        engine: ExecutionEngine = _make_engine(strategy, sizer, commission_bps=0.0)
+        result: BacktestResult = engine.run(bars=bars, asset=_BTC)
+
+        assert len(result.trades) == 1
+        assert result.trades[0].gross_pnl > 0.0
+
+
+# ---------------------------------------------------------------------------
+# TestStopLossAndTakeProfit
+# ---------------------------------------------------------------------------
+
+
+class TestStopLossAndTakeProfit:
+    """Tests for SL/TP exit logic."""
+
+    def test_long_stop_loss_triggered_by_low(self) -> None:
+        """Long position stop-loss is triggered when bar low <= stop_loss."""
+        from src.app.backtest.application.execution import _check_sl_tp
+
+        pos: Position = Position(
+            asset=_BTC,
+            side=Side.LONG,
+            size=0.25,
+            entry_price=40_000.0,
+            entry_time=_T0,
+            stop_loss=39_000.0,
+        )
+        # low_price=38_000 <= 39_000 SL → should trigger
+        exit_price: float | None = _check_sl_tp(pos, high_price=40_500.0, low_price=38_000.0)
+        assert exit_price == pytest.approx(39_000.0)
+
+    def test_long_take_profit_triggered_by_high(self) -> None:
+        """Long position take-profit is triggered when bar high >= take_profit."""
+        from src.app.backtest.application.execution import _check_sl_tp
+
+        pos: Position = Position(
+            asset=_BTC,
+            side=Side.LONG,
+            size=0.25,
+            entry_price=40_000.0,
+            entry_time=_T0,
+            take_profit=41_000.0,
+        )
+        exit_price: float | None = _check_sl_tp(pos, high_price=41_500.0, low_price=39_500.0)
+        assert exit_price == pytest.approx(41_000.0)
+
+    def test_short_stop_loss_triggered_by_high(self) -> None:
+        """Short position stop-loss triggers when bar high >= stop_loss."""
+        from src.app.backtest.application.execution import _check_sl_tp
+
+        pos: Position = Position(
+            asset=_BTC,
+            side=Side.SHORT,
+            size=0.25,
+            entry_price=40_000.0,
+            entry_time=_T0,
+            stop_loss=41_000.0,
+        )
+        exit_price: float | None = _check_sl_tp(pos, high_price=41_500.0, low_price=39_500.0)
+        assert exit_price == pytest.approx(41_000.0)
+
+    def test_short_take_profit_triggered_by_low(self) -> None:
+        """Short position take-profit triggers when bar low <= take_profit."""
+        from src.app.backtest.application.execution import _check_sl_tp
+
+        pos: Position = Position(
+            asset=_BTC,
+            side=Side.SHORT,
+            size=0.25,
+            entry_price=40_000.0,
+            entry_time=_T0,
+            take_profit=39_000.0,
+        )
+        exit_price: float | None = _check_sl_tp(pos, high_price=40_500.0, low_price=38_500.0)
+        assert exit_price == pytest.approx(39_000.0)
+
+    def test_sl_takes_priority_over_tp(self) -> None:
+        """Stop-loss is checked before take-profit (worst-case execution)."""
+        from src.app.backtest.application.execution import _check_sl_tp
+
+        pos: Position = Position(
+            asset=_BTC,
+            side=Side.LONG,
+            size=0.25,
+            entry_price=40_000.0,
+            entry_time=_T0,
+            stop_loss=39_000.0,
+            take_profit=41_000.0,
+        )
+        # Both SL and TP triggered in same bar
+        exit_price: float | None = _check_sl_tp(pos, high_price=41_500.0, low_price=38_500.0)
+        assert exit_price == pytest.approx(39_000.0)  # SL wins
+
+    def test_no_sl_tp_returns_none(self) -> None:
+        """No SL/TP configured always returns None."""
+        from src.app.backtest.application.execution import _check_sl_tp
+
+        pos: Position = Position(
+            asset=_BTC,
+            side=Side.LONG,
+            size=0.25,
+            entry_price=40_000.0,
+            entry_time=_T0,
+        )
+        result: float | None = _check_sl_tp(pos, high_price=42_000.0, low_price=38_000.0)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# TestStalenessSkip
+# ---------------------------------------------------------------------------
+
+
+class TestStalenessSkip:
+    """Tests for gap-detection and staleness-skip behavior."""
+
+    def test_gap_exceeding_threshold_skips_bar(self) -> None:
+        """Bars with a gap > 2x median bar duration are skipped."""
+        # Normal bars at 1-hour intervals; one bar has a 24-hour gap
+        t0: datetime = _T0
+        t1: datetime = _T0 + timedelta(hours=1)
+        t2: datetime = _T0 + timedelta(hours=25)  # 24h gap >> 2 * 1h
+        t3: datetime = _T0 + timedelta(hours=26)
+        bars: pl.DataFrame = pl.DataFrame(
+            {
+                "timestamp": [t0, t1, t2, t3],
+                "open": [40_000.0] * 4,
+                "high": [40_200.0] * 4,
+                "low": [39_800.0] * 4,
+                "close": [40_000.0] * 4,
+                "volume": [10.0] * 4,
+            }
+        )
+        engine: ExecutionEngine = _make_engine(NeverTradeStrategy(), FixedNotionalSizer())
+        result: BacktestResult = engine.run(bars=bars, asset=_BTC)
+        # Engine should complete without error; equity curve should have <= 4 points
+        # (bar t2 is skipped)
+        assert len(result.equity_curve.values) <= 4
+
+    def test_uniform_bars_no_staleness_skip(self) -> None:
+        """Uniform 1-hour bars do not trigger staleness skip."""
+        n: int = 10
+        bars: pl.DataFrame = make_bars(n, start_price=40_000.0)
+        engine: ExecutionEngine = _make_engine(NeverTradeStrategy(), FixedNotionalSizer())
+        result: BacktestResult = engine.run(bars=bars, asset=_BTC)
+        assert len(result.equity_curve.values) == n
+
+
+# ---------------------------------------------------------------------------
+# TestEdgeCases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Tests for edge cases: single bar, never-trade, zero volume, etc."""
+
+    def test_single_bar_never_trade_returns_initial_cash(self) -> None:
+        """With a single bar and no trades, equity equals initial cash."""
+        bars: pl.DataFrame = make_bars(1, start_price=40_000.0)
+        engine: ExecutionEngine = _make_engine(NeverTradeStrategy(), FixedNotionalSizer())
+        result: BacktestResult = engine.run(bars=bars, asset=_BTC, initial_cash=INITIAL_CASH)
+        assert result.equity_curve.values[0] == pytest.approx(INITIAL_CASH)
+
+    def test_never_trade_strategy_produces_no_trades(self) -> None:
+        """NeverTradeStrategy results in zero completed trades."""
+        bars: pl.DataFrame = make_bars(20, start_price=40_000.0)
+        engine: ExecutionEngine = _make_engine(NeverTradeStrategy(), FixedNotionalSizer())
+        result: BacktestResult = engine.run(bars=bars, asset=_BTC)
+        assert len(result.trades) == 0
+
+    def test_never_trade_equity_stays_constant(self) -> None:
+        """With no trades, all equity values equal initial cash."""
+        bars: pl.DataFrame = make_bars(5, start_price=40_000.0)
+        engine: ExecutionEngine = _make_engine(NeverTradeStrategy(), FixedNotionalSizer())
+        result: BacktestResult = engine.run(bars=bars, asset=_BTC, initial_cash=INITIAL_CASH)
+        for val in result.equity_curve.values:
+            assert val == pytest.approx(INITIAL_CASH)
+
+    def test_zero_volume_bars_handled(self) -> None:
+        """Bars with zero volume are processed without error."""
+        # Use NeverTradeStrategy to avoid opening a position that would need
+        # entry_time < exit_time on the last bar's liquidation
+        bars: pl.DataFrame = make_bars(5, start_price=40_000.0, volume=0.0)
+        engine: ExecutionEngine = _make_engine(NeverTradeStrategy(), FixedNotionalSizer())
+        result: BacktestResult = engine.run(bars=bars, asset=_BTC)
+        # Main check: no exception raised, equity curve has correct length
+        assert len(result.equity_curve.values) == 5
+
+    def test_opposite_signal_closes_existing_position(self) -> None:
+        """A SHORT signal while LONG is open first closes the long, then opens short."""
+
+        class _FlipStrategy:
+            """Strategy that goes LONG on bar[0], SHORT on bar[1]."""
+
+            def __init__(self) -> None:
+                self._call: int = 0
+
+            def on_bar(
+                self,
+                timestamp: datetime,
+                features: pl.DataFrame,  # noqa: ARG002
+                portfolio: object,  # noqa: ARG002
+            ) -> list[Signal]:
+                self._call += 1
+                if self._call == 1:
+                    return [Signal(asset=_BTC, side=Side.LONG, strength=1.0, timestamp=timestamp)]
+                if self._call == 2:  # noqa: PLR2004
+                    return [Signal(asset=_BTC, side=Side.SHORT, strength=1.0, timestamp=timestamp)]
+                return []
+
+        bars: pl.DataFrame = make_bars(4, start_price=40_000.0)
+        engine: ExecutionEngine = _make_engine(_FlipStrategy(), FixedNotionalSizer(10_000.0))
+        result: BacktestResult = engine.run(bars=bars, asset=_BTC)
+        # At minimum the LONG position was closed and a new SHORT opened
+        # So there must be at least one completed trade (the closed long)
+        assert len(result.trades) >= 1
+
+    def test_insufficient_cash_skips_trade(self) -> None:
+        """Sizer requesting more than available cash results in no trade."""
+        bars: pl.DataFrame = make_bars(3, start_price=40_000.0)
+        # Request notional larger than initial_cash
+        strategy: SingleSignalStrategy = SingleSignalStrategy(_BTC, Side.LONG)
+        sizer: FixedNotionalSizer = FixedNotionalSizer(notional=999_999_999.0)
+        engine: ExecutionEngine = _make_engine(strategy, sizer, commission_bps=0.0)
+        result: BacktestResult = engine.run(bars=bars, asset=_BTC, initial_cash=INITIAL_CASH)
+        assert len(result.trades) == 0
+
+    def test_last_bar_position_is_liquidated(self) -> None:
+        """Open position at the end of bars is liquidated at last close."""
+        bars: pl.DataFrame = make_bars(3, start_price=40_000.0)
+        strategy: SingleSignalStrategy = SingleSignalStrategy(_BTC, Side.LONG)
+        sizer: FixedNotionalSizer = FixedNotionalSizer(notional=10_000.0)
+        engine: ExecutionEngine = _make_engine(strategy, sizer, commission_bps=0.0)
+        result: BacktestResult = engine.run(bars=bars, asset=_BTC)
+        # Position opened at bar[1] should be liquidated: 1 trade total
+        assert len(result.trades) == 1
+        assert result.trades[0].exit_price == pytest.approx(40_000.0)  # last close (flat)
+
+
+# ---------------------------------------------------------------------------
+# TestEquityCurveManualVerification
+# ---------------------------------------------------------------------------
+
+
+class TestEquityCurveManualVerification:
+    """Manual verification of equity curve values against expected calculations."""
+
+    def test_never_trade_equity_curve_matches_initial_cash(self) -> None:
+        """All equity snapshots equal initial cash when no trades are made."""
+        initial: float = 75_000.0
+        bars: pl.DataFrame = make_bars(5, start_price=40_000.0)
+        engine: ExecutionEngine = _make_engine(NeverTradeStrategy(), FixedNotionalSizer())
+        result: BacktestResult = engine.run(bars=bars, asset=_BTC, initial_cash=initial)
+        expected_values: list[float] = [initial] * 5
+        for actual, expected in zip(result.equity_curve.values, expected_values, strict=True):
+            assert actual == pytest.approx(expected)
+
+    def test_equity_timestamps_match_bar_timestamps(self) -> None:
+        """Equity curve timestamps exactly match input bar timestamps."""
+        n: int = 5
+        bars: pl.DataFrame = make_bars(n, start_price=40_000.0)
+        engine: ExecutionEngine = _make_engine(NeverTradeStrategy(), FixedNotionalSizer())
+        result: BacktestResult = engine.run(bars=bars, asset=_BTC)
+        bar_timestamps: list[datetime] = bars.get_column("timestamp").to_list()
+        assert result.equity_curve.timestamps == bar_timestamps
+
+    def test_buy_and_hold_equity_includes_unrealised_pnl(self) -> None:
+        """Equity snapshots include unrealised P&L from open positions."""
+        # Rising prices: open long at bar[1], equity should increase thereafter
+        bars: pl.DataFrame = make_bars(5, start_price=40_000.0, price_step=100.0)
+        from src.app.backtest.application.baselines import BuyAndHoldStrategy
+
+        strategy: BuyAndHoldStrategy = BuyAndHoldStrategy(asset=_BTC)
+        sizer: FixedFractionalSizer = FixedFractionalSizer(fraction=0.5)
+        config: ExecutionConfig = ExecutionConfig(commission_bps=0.0)
+        engine: ExecutionEngine = ExecutionEngine(config=config, strategy=strategy, sizer=sizer)
+        result: BacktestResult = engine.run(bars=bars, asset=_BTC, initial_cash=INITIAL_CASH)
+
+        # After buying in bar[1], equity at later bars should reflect price gains
+        # (rising market → equity should be >= initial after bar[2])
+        if len(result.equity_curve.values) >= 3:  # noqa: PLR2004
+            assert result.equity_curve.values[2] >= result.equity_curve.values[1]

--- a/src/tests/backtest/test_metrics.py
+++ b/src/tests/backtest/test_metrics.py
@@ -1,0 +1,366 @@
+"""Unit tests for backtest metrics: Sharpe, Lo correction, drawdown, trade stats."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, UTC
+
+import numpy as np
+import pytest
+
+from src.app.backtest.application.metrics import (
+    BacktestMetrics,
+    compute_buy_and_hold_metrics,
+    compute_metrics,
+)
+from src.app.backtest.domain.entities import EquityCurve, Trade
+from src.app.backtest.domain.value_objects import Side
+from src.app.ohlcv.domain.value_objects import Asset
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_T0: datetime = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+_ONE_HOUR: timedelta = timedelta(hours=1)
+_ONE_DAY: timedelta = timedelta(days=1)
+_BTC: Asset = Asset(symbol="BTCUSDT")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_equity_curve(values: list[float], start: datetime = _T0) -> EquityCurve:
+    """Build an EquityCurve from a list of equity values at daily intervals.
+
+    Uses daily spacing to avoid OverflowError in _annualized_return when the
+    duration is sub-hour (exponent 365.25/duration_days would be enormous).
+    """
+    timestamps: list[datetime] = [start + i * _ONE_DAY for i in range(len(values))]
+    return EquityCurve(timestamps=timestamps, values=values)
+
+
+def _make_hourly_equity_curve(values: list[float], start: datetime = _T0) -> EquityCurve:
+    """Build an EquityCurve at hourly intervals (for tests that need sub-day spacing)."""
+    timestamps: list[datetime] = [start + i * _ONE_HOUR for i in range(len(values))]
+    return EquityCurve(timestamps=timestamps, values=values)
+
+
+def _make_trade(
+    *,
+    net_pnl: float,
+    gross_pnl: float | None = None,
+    entry_price: float = 40_000.0,
+    exit_price: float = 41_000.0,
+    side: Side = Side.LONG,
+    size: float = 0.25,
+    offset_hours: int = 0,
+) -> Trade:
+    """Build a minimal Trade for metrics tests."""
+    gp: float = gross_pnl if gross_pnl is not None else net_pnl
+    comm: float = max(0.0, gp - net_pnl)
+    entry_time: datetime = _T0 + timedelta(hours=offset_hours)
+    exit_time: datetime = entry_time + _ONE_HOUR
+    return Trade(
+        asset=_BTC,
+        side=side,
+        size=size,
+        entry_price=entry_price,
+        exit_price=exit_price,
+        entry_time=entry_time,
+        exit_time=exit_time,
+        gross_pnl=gp,
+        net_pnl=net_pnl,
+        commission_paid=comm,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestComputeMetrics — return metrics
+# ---------------------------------------------------------------------------
+
+
+class TestComputeMetricsReturn:
+    """Tests for return metric calculations."""
+
+    def test_total_return_flat_equity(self) -> None:
+        """Flat equity curve produces zero total return."""
+        ec: EquityCurve = _make_equity_curve([100_000.0, 100_000.0, 100_000.0])
+        metrics: BacktestMetrics = compute_metrics(ec, [])
+        assert metrics.total_return == pytest.approx(0.0)
+
+    def test_total_return_doubling(self) -> None:
+        """Equity doubling produces total_return == 1.0 (100%)."""
+        ec: EquityCurve = _make_equity_curve([100_000.0, 200_000.0])
+        metrics: BacktestMetrics = compute_metrics(ec, [])
+        assert metrics.total_return == pytest.approx(1.0)
+
+    def test_total_return_halving(self) -> None:
+        """Equity halving produces total_return == -0.5."""
+        ec: EquityCurve = _make_equity_curve([100_000.0, 50_000.0])
+        metrics: BacktestMetrics = compute_metrics(ec, [])
+        assert metrics.total_return == pytest.approx(-0.5)
+
+    def test_single_point_returns_none_for_computed_metrics(self) -> None:
+        """Single-point equity curve returns None for all computed metrics."""
+        ec: EquityCurve = _make_equity_curve([100_000.0])
+        metrics: BacktestMetrics = compute_metrics(ec, [])
+        assert metrics.total_return is None
+        assert metrics.sharpe_ratio is None
+        assert metrics.max_drawdown is None
+
+    def test_cagr_equals_annualized_return(self) -> None:
+        """cagr field is always equal to annualized_return."""
+        ec: EquityCurve = _make_equity_curve([100_000.0, 110_000.0, 105_000.0])
+        metrics: BacktestMetrics = compute_metrics(ec, [])
+        assert metrics.cagr == metrics.annualized_return
+
+
+# ---------------------------------------------------------------------------
+# TestComputeMetrics — max drawdown
+# ---------------------------------------------------------------------------
+
+
+class TestComputeMetricsDrawdown:
+    """Tests for drawdown metric calculations."""
+
+    def test_no_drawdown_on_monotone_increasing_equity(self) -> None:
+        """Monotone increasing equity has max drawdown == 0."""
+        ec: EquityCurve = _make_equity_curve([100_000.0, 101_000.0, 102_000.0, 103_000.0])
+        metrics: BacktestMetrics = compute_metrics(ec, [])
+        assert metrics.max_drawdown == pytest.approx(0.0)
+
+    def test_drawdown_known_value(self) -> None:
+        """Max drawdown computed correctly for a known equity sequence."""
+        # peak=120, trough=90 → drawdown = (90-120)/120 = -0.25
+        ec: EquityCurve = _make_equity_curve([100_000.0, 120_000.0, 90_000.0, 100_000.0])
+        metrics: BacktestMetrics = compute_metrics(ec, [])
+        assert metrics.max_drawdown is not None
+        assert metrics.max_drawdown == pytest.approx(-0.25, rel=1e-6)
+
+    def test_max_drawdown_is_non_positive(self) -> None:
+        """max_drawdown is always <= 0."""
+        ec: EquityCurve = _make_equity_curve([100_000.0, 90_000.0, 80_000.0, 95_000.0])
+        metrics: BacktestMetrics = compute_metrics(ec, [])
+        assert metrics.max_drawdown is not None
+        assert metrics.max_drawdown <= 0.0
+
+    def test_max_drawdown_duration_days_positive(self) -> None:
+        """max_drawdown_duration_days is positive when there is a drawdown."""
+        ec: EquityCurve = _make_equity_curve([100_000.0, 120_000.0, 90_000.0, 90_000.0, 115_000.0])
+        metrics: BacktestMetrics = compute_metrics(ec, [])
+        assert metrics.max_drawdown_duration_days is not None
+        assert metrics.max_drawdown_duration_days > 0.0
+
+
+# ---------------------------------------------------------------------------
+# TestComputeMetrics — Sharpe and Lo correction
+# ---------------------------------------------------------------------------
+
+
+class TestSharpeAndLoCorrection:
+    """Tests for Sharpe ratio and Lo (2002) autocorrelation correction."""
+
+    def test_sharpe_none_for_constant_returns(self) -> None:
+        """Constant equity (zero variance) returns None Sharpe."""
+        ec: EquityCurve = _make_equity_curve([100_000.0] * 20)
+        metrics: BacktestMetrics = compute_metrics(ec, [])
+        assert metrics.sharpe_ratio is None
+
+    def test_positive_sharpe_for_trending_up(self) -> None:
+        """Steadily rising equity yields a positive Sharpe ratio."""
+        ec: EquityCurve = _make_equity_curve([100_000.0 + i * 100.0 for i in range(50)])
+        metrics: BacktestMetrics = compute_metrics(ec, [])
+        assert metrics.sharpe_ratio is not None
+        assert metrics.sharpe_ratio > 0.0
+
+    def test_negative_sharpe_for_trending_down(self) -> None:
+        """Steadily falling equity yields a negative Sharpe ratio."""
+        ec: EquityCurve = _make_equity_curve([100_000.0 - i * 100.0 for i in range(50) if 100_000.0 - i * 100.0 > 0])
+        metrics: BacktestMetrics = compute_metrics(ec, [])
+        assert metrics.sharpe_ratio is not None
+        assert metrics.sharpe_ratio < 0.0
+
+    def test_lo_correction_factor_less_than_one_for_positive_autocorr(self) -> None:
+        """Positive autocorrelation produces lo_correction_factor < 1.0."""
+        # Generate AR(1) returns with phi=0.8 (strong positive autocorrelation)
+        rng: np.random.Generator = np.random.default_rng(42)
+        n: int = 300
+        phi: float = 0.8
+        noise: np.ndarray = rng.normal(0.0, 0.001, n)
+        returns: np.ndarray = np.zeros(n)
+        for i in range(1, n):
+            returns[i] = phi * returns[i - 1] + noise[i]
+        # Convert to equity curve
+        equity: list[float] = [100_000.0]
+        for r in returns[1:]:
+            equity.append(equity[-1] * (1.0 + r))
+        ec: EquityCurve = _make_equity_curve(equity)
+        metrics: BacktestMetrics = compute_metrics(ec, [], lo_correction_lags=6)
+
+        assert metrics.lo_correction_factor is not None
+        assert metrics.lo_correction_factor < 1.0
+
+    def test_lo_corrected_sharpe_less_than_naive_for_positive_autocorr(self) -> None:
+        """With positive autocorrelation, Lo-corrected Sharpe < naive Sharpe."""
+        rng: np.random.Generator = np.random.default_rng(99)
+        n: int = 300
+        phi: float = 0.7
+        noise: np.ndarray = rng.normal(0.0005, 0.001, n)
+        returns: np.ndarray = np.zeros(n)
+        returns[0] = noise[0]
+        for i in range(1, n):
+            returns[i] = phi * returns[i - 1] + noise[i]
+        equity: list[float] = [100_000.0]
+        for r in returns[1:]:
+            equity.append(equity[-1] * (1.0 + r))
+        ec: EquityCurve = _make_equity_curve(equity)
+        metrics: BacktestMetrics = compute_metrics(ec, [], lo_correction_lags=6)
+
+        assert metrics.sharpe_ratio is not None
+        assert metrics.sharpe_ratio_lo_corrected is not None
+        assert metrics.sharpe_ratio_lo_corrected < metrics.sharpe_ratio
+
+    def test_lo_correction_factor_near_one_for_iid_returns(self) -> None:
+        """IID returns have Lo correction factor close to 1.0."""
+        rng: np.random.Generator = np.random.default_rng(0)
+        n: int = 500
+        returns: np.ndarray = rng.normal(0.0002, 0.001, n)
+        equity: list[float] = [100_000.0]
+        for r in returns:
+            equity.append(equity[-1] * (1.0 + r))
+        ec: EquityCurve = _make_equity_curve(equity)
+        metrics: BacktestMetrics = compute_metrics(ec, [], lo_correction_lags=6)
+
+        assert metrics.lo_correction_factor is not None
+        # IID returns have near-zero autocorrelation → eta ≈ 1
+        assert metrics.lo_correction_factor == pytest.approx(1.0, abs=0.2)
+
+
+# ---------------------------------------------------------------------------
+# TestComputeMetrics — trade statistics
+# ---------------------------------------------------------------------------
+
+
+class TestTradeStatistics:
+    """Tests for trade-level metrics (win rate, profit factor, etc.)."""
+
+    def test_trade_metrics_none_below_min_trade_count(self) -> None:
+        """Trade metrics are None when trades < min_trade_count."""
+        ec: EquityCurve = _make_equity_curve([100_000.0, 101_000.0])
+        trades: list[Trade] = [_make_trade(net_pnl=500.0)]
+        metrics: BacktestMetrics = compute_metrics(ec, trades, min_trade_count=30)
+        assert metrics.win_rate is None
+        assert metrics.profit_factor is None
+
+    def test_win_rate_all_winners(self) -> None:
+        """All winning trades → win_rate == 1.0."""
+        ec: EquityCurve = _make_equity_curve([100_000.0 + i * 100 for i in range(35)])
+        trades: list[Trade] = [_make_trade(net_pnl=100.0, offset_hours=i) for i in range(30)]
+        metrics: BacktestMetrics = compute_metrics(ec, trades, min_trade_count=30)
+        assert metrics.win_rate is not None
+        assert metrics.win_rate == pytest.approx(1.0)
+
+    def test_win_rate_all_losers(self) -> None:
+        """All losing trades → win_rate == 0.0."""
+        ec: EquityCurve = _make_equity_curve([100_000.0 - i * 100 for i in range(35) if 100_000.0 - i * 100 > 0])
+        trades: list[Trade] = [_make_trade(net_pnl=-100.0, offset_hours=i) for i in range(30)]
+        metrics: BacktestMetrics = compute_metrics(ec, trades, min_trade_count=30)
+        assert metrics.win_rate is not None
+        assert metrics.win_rate == pytest.approx(0.0)
+
+    def test_win_rate_half_and_half(self) -> None:
+        """Equal winners and losers → win_rate == 0.5."""
+        ec: EquityCurve = _make_equity_curve([100_000.0] * 35)
+        winners: list[Trade] = [_make_trade(net_pnl=100.0, offset_hours=i * 2) for i in range(15)]
+        losers: list[Trade] = [_make_trade(net_pnl=-100.0, offset_hours=i * 2 + 1) for i in range(15)]
+        trades: list[Trade] = winners + losers
+        metrics: BacktestMetrics = compute_metrics(ec, trades, min_trade_count=30)
+        assert metrics.win_rate is not None
+        assert metrics.win_rate == pytest.approx(0.5)
+
+    def test_profit_factor_known_value(self) -> None:
+        """Profit factor computed correctly: gross_wins / abs(gross_losses)."""
+        ec: EquityCurve = _make_equity_curve([100_000.0] * 35)
+        # 20 winners at +200 each, 10 losers at -100 each
+        win_trades: list[Trade] = [_make_trade(net_pnl=200.0, offset_hours=i) for i in range(20)]
+        loss_trades: list[Trade] = [_make_trade(net_pnl=-100.0, offset_hours=20 + i) for i in range(10)]
+        trades: list[Trade] = win_trades + loss_trades
+        metrics: BacktestMetrics = compute_metrics(ec, trades, min_trade_count=30)
+        assert metrics.profit_factor is not None
+        expected_pf: float = (20 * 200.0) / (10 * 100.0)  # 4.0
+        assert metrics.profit_factor == pytest.approx(expected_pf)
+
+    def test_max_consecutive_losses_known_sequence(self) -> None:
+        """max_consecutive_losses computed correctly for known PnL sequence."""
+        ec: EquityCurve = _make_equity_curve([100_000.0] * 35)
+        # W L L L W W L W L L  (3 consecutive losses is the max run)
+        pnls: list[float] = [100, -50, -50, -50, 100, 100, -50, 100, -50, -50]
+        pnls.extend([100.0] * 20)  # Pad to reach min_trade_count=30
+        trades: list[Trade] = [_make_trade(net_pnl=p, offset_hours=i) for i, p in enumerate(pnls)]
+        metrics: BacktestMetrics = compute_metrics(ec, trades, min_trade_count=30)
+        assert metrics.max_consecutive_losses is not None
+        assert metrics.max_consecutive_losses == 3
+
+    def test_n_trades_count_matches(self) -> None:
+        """n_trades matches the length of the trades list."""
+        ec: EquityCurve = _make_equity_curve([100_000.0, 101_000.0])
+        n: int = 7
+        trades: list[Trade] = [_make_trade(net_pnl=50.0, offset_hours=i) for i in range(n)]
+        metrics: BacktestMetrics = compute_metrics(ec, trades)
+        assert metrics.n_trades == n
+
+    def test_sufficient_sample_true_at_threshold(self) -> None:
+        """sufficient_sample is True when n_trades == min_trade_count."""
+        ec: EquityCurve = _make_equity_curve([100_000.0] * 32)
+        min_count: int = 30
+        trades: list[Trade] = [_make_trade(net_pnl=10.0, offset_hours=i) for i in range(min_count)]
+        metrics: BacktestMetrics = compute_metrics(ec, trades, min_trade_count=min_count)
+        assert metrics.sufficient_sample is True
+
+
+# ---------------------------------------------------------------------------
+# TestComputeBuyAndHoldMetrics
+# ---------------------------------------------------------------------------
+
+
+class TestComputeBuyAndHoldMetrics:
+    """Tests for compute_buy_and_hold_metrics."""
+
+    def test_buy_and_hold_n_trades_zero(self) -> None:
+        """Buy-and-hold metrics always have n_trades == 0."""
+        ec: EquityCurve = _make_equity_curve([100_000.0, 110_000.0, 105_000.0])
+        metrics: BacktestMetrics = compute_buy_and_hold_metrics(ec)
+        assert metrics.n_trades == 0
+
+    def test_buy_and_hold_sufficient_sample_always_true(self) -> None:
+        """sufficient_sample is always True for buy-and-hold."""
+        ec: EquityCurve = _make_equity_curve([100_000.0, 110_000.0])
+        metrics: BacktestMetrics = compute_buy_and_hold_metrics(ec)
+        assert metrics.sufficient_sample is True
+
+    def test_buy_and_hold_trade_metrics_are_none(self) -> None:
+        """Trade-level metrics are always None for buy-and-hold."""
+        ec: EquityCurve = _make_equity_curve([100_000.0 + i * 500 for i in range(20)])
+        metrics: BacktestMetrics = compute_buy_and_hold_metrics(ec)
+        assert metrics.win_rate is None
+        assert metrics.profit_factor is None
+        assert metrics.avg_win_loss_ratio is None
+        assert metrics.max_consecutive_losses is None
+
+    def test_buy_and_hold_total_return_consistent(self) -> None:
+        """Buy-and-hold total return matches equivalent strategy run."""
+        values: list[float] = [100_000.0, 105_000.0, 110_000.0]
+        ec: EquityCurve = _make_equity_curve(values)
+        bh_metrics: BacktestMetrics = compute_buy_and_hold_metrics(ec)
+        strat_metrics: BacktestMetrics = compute_metrics(ec, [])
+        assert bh_metrics.total_return == pytest.approx(strat_metrics.total_return or 0.0)
+
+    def test_single_point_buy_and_hold_returns_empty_metrics(self) -> None:
+        """Single-point equity curve returns minimal buy-and-hold metrics."""
+        ec: EquityCurve = _make_equity_curve([100_000.0])
+        metrics: BacktestMetrics = compute_buy_and_hold_metrics(ec)
+        assert metrics.n_trades == 0
+        assert metrics.sufficient_sample is True

--- a/src/tests/backtest/test_position_sizer.py
+++ b/src/tests/backtest/test_position_sizer.py
@@ -1,0 +1,315 @@
+"""Unit tests for FixedFractionalSizer and RegimeConditionalSizer."""
+
+from __future__ import annotations
+
+from datetime import datetime, UTC
+
+import pytest
+from pydantic import ValidationError
+
+from src.app.backtest.application.position_sizer import (
+    FixedFractionalSizer,
+    RegimeConditionalSizer,
+)
+from src.app.backtest.domain.entities import Signal
+from src.app.backtest.domain.value_objects import PortfolioSnapshot, Side
+from src.app.ohlcv.domain.value_objects import Asset
+from src.tests.backtest.conftest import make_snapshot
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_T0: datetime = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+_BTC: Asset = Asset(symbol="BTCUSDT")
+_DEFAULT_EQUITY: float = 100_000.0
+_DEFAULT_FRACTION: float = 0.02
+
+
+def _make_signal(strength: float = 1.0, side: Side = Side.LONG) -> Signal:
+    """Build a test signal with given strength."""
+    return Signal(asset=_BTC, side=side, strength=strength, timestamp=_T0)
+
+
+# ---------------------------------------------------------------------------
+# FixedFractionalSizer
+# ---------------------------------------------------------------------------
+
+
+class TestFixedFractionalSizer:
+    """Tests for FixedFractionalSizer."""
+
+    def test_default_fraction_is_two_percent(self) -> None:
+        """Default fraction is 0.02."""
+        sizer: FixedFractionalSizer = FixedFractionalSizer()
+        assert sizer.fraction == pytest.approx(_DEFAULT_FRACTION)
+
+    def test_size_full_strength_returns_fraction_of_equity(self) -> None:
+        """At strength=1.0, notional equals equity * fraction."""
+        sizer: FixedFractionalSizer = FixedFractionalSizer(fraction=0.02)
+        snapshot: PortfolioSnapshot = make_snapshot(equity=_DEFAULT_EQUITY)
+        signal: Signal = _make_signal(strength=1.0)
+        notional: float = sizer.size(signal, snapshot, 0.0)
+        expected: float = _DEFAULT_EQUITY * 0.02 * 1.0
+        assert notional == pytest.approx(expected)
+
+    def test_size_half_strength_returns_half_notional(self) -> None:
+        """At strength=0.5, notional is half of full-strength notional."""
+        sizer: FixedFractionalSizer = FixedFractionalSizer(fraction=0.02)
+        snapshot: PortfolioSnapshot = make_snapshot(equity=_DEFAULT_EQUITY)
+        full_signal: Signal = _make_signal(strength=1.0)
+        half_signal: Signal = _make_signal(strength=0.5)
+        full_notional: float = sizer.size(full_signal, snapshot, 0.0)
+        half_notional: float = sizer.size(half_signal, snapshot, 0.0)
+        assert half_notional == pytest.approx(full_notional * 0.5)
+
+    def test_size_zero_equity_returns_zero(self) -> None:
+        """Zero portfolio equity yields zero notional."""
+        sizer: FixedFractionalSizer = FixedFractionalSizer(fraction=0.1)
+        snapshot: PortfolioSnapshot = make_snapshot(equity=0.0, cash=0.0)
+        signal: Signal = _make_signal(strength=1.0)
+        notional: float = sizer.size(signal, snapshot, 0.0)
+        assert notional == pytest.approx(0.0)
+
+    def test_size_large_equity(self) -> None:
+        """Sizer scales correctly with large equity values."""
+        equity: float = 10_000_000.0
+        fraction: float = 0.05
+        sizer: FixedFractionalSizer = FixedFractionalSizer(fraction=fraction)
+        snapshot: PortfolioSnapshot = make_snapshot(equity=equity)
+        signal: Signal = _make_signal(strength=1.0)
+        notional: float = sizer.size(signal, snapshot, 0.0)
+        assert notional == pytest.approx(equity * fraction)
+
+    def test_volatility_parameter_is_ignored(self) -> None:
+        """FixedFractionalSizer ignores volatility — result is identical for any vol."""
+        sizer: FixedFractionalSizer = FixedFractionalSizer(fraction=0.02)
+        snapshot: PortfolioSnapshot = make_snapshot(equity=_DEFAULT_EQUITY)
+        signal: Signal = _make_signal(strength=1.0)
+        notional_low_vol: float = sizer.size(signal, snapshot, 0.001)
+        notional_high_vol: float = sizer.size(signal, snapshot, 1.0)
+        assert notional_low_vol == pytest.approx(notional_high_vol)
+
+    def test_fraction_above_one_raises(self) -> None:
+        """fraction > 1.0 raises ValidationError."""
+        with pytest.raises(ValidationError):
+            FixedFractionalSizer(fraction=1.1)
+
+    def test_fraction_zero_raises(self) -> None:
+        """fraction == 0.0 raises ValidationError (must be > 0)."""
+        with pytest.raises(ValidationError):
+            FixedFractionalSizer(fraction=0.0)
+
+    def test_fraction_one_is_valid(self) -> None:
+        """fraction == 1.0 is a valid edge value."""
+        sizer: FixedFractionalSizer = FixedFractionalSizer(fraction=1.0)
+        assert sizer.fraction == pytest.approx(1.0)
+
+    def test_different_assets_same_notional(self) -> None:
+        """Sizer does not differentiate by asset — notional depends only on equity."""
+        sizer: FixedFractionalSizer = FixedFractionalSizer(fraction=0.02)
+        snapshot: PortfolioSnapshot = make_snapshot(equity=_DEFAULT_EQUITY)
+        btc_signal: Signal = Signal(
+            asset=Asset(symbol="BTCUSDT"),
+            side=Side.LONG,
+            strength=1.0,
+            timestamp=_T0,
+        )
+        eth_signal: Signal = Signal(
+            asset=Asset(symbol="ETHUSDT"),
+            side=Side.LONG,
+            strength=1.0,
+            timestamp=_T0,
+        )
+        assert sizer.size(btc_signal, snapshot, 0.0) == pytest.approx(sizer.size(eth_signal, snapshot, 0.0))
+
+    @pytest.mark.parametrize(
+        ("fraction", "equity", "strength", "expected"),
+        [
+            (0.01, 100_000.0, 1.0, 1_000.0),
+            (0.05, 50_000.0, 0.5, 1_250.0),
+            (0.10, 200_000.0, 0.25, 5_000.0),
+            (1.00, 100_000.0, 1.0, 100_000.0),
+        ],
+    )
+    def test_size_parametrized_known_values(
+        self,
+        fraction: float,
+        equity: float,
+        strength: float,
+        expected: float,
+    ) -> None:
+        """Parametrized check: notional matches equity * fraction * strength."""
+        sizer: FixedFractionalSizer = FixedFractionalSizer(fraction=fraction)
+        snapshot: PortfolioSnapshot = make_snapshot(equity=equity)
+        signal: Signal = _make_signal(strength=strength)
+        notional: float = sizer.size(signal, snapshot, 0.0)
+        assert notional == pytest.approx(expected)
+
+
+# ---------------------------------------------------------------------------
+# RegimeConditionalSizer
+# ---------------------------------------------------------------------------
+
+
+class TestRegimeConditionalSizer:
+    """Tests for RegimeConditionalSizer."""
+
+    def _make_sizer(
+        self,
+        *,
+        da_estimate: float = 0.60,
+        pe_estimate: float = 0.90,
+        break_even_da: float = 0.55,
+        high_entropy_threshold: float = 0.98,
+        high_entropy_reduction: float = 0.5,
+        base_fraction: float = 0.02,
+        is_tier_b: bool = False,
+        tier_b_kelly_multiplier: float = 0.5,
+    ) -> RegimeConditionalSizer:
+        """Build a RegimeConditionalSizer with given parameters."""
+        return RegimeConditionalSizer(
+            base_fraction=base_fraction,
+            break_even_da=break_even_da,
+            high_entropy_threshold=high_entropy_threshold,
+            high_entropy_reduction=high_entropy_reduction,
+            da_estimate=da_estimate,
+            pe_estimate=pe_estimate,
+            tier_b_kelly_multiplier=tier_b_kelly_multiplier,
+            is_tier_b=is_tier_b,
+        )
+
+    def test_above_breakeven_da_returns_positive(self) -> None:
+        """DA above break-even yields positive notional."""
+        sizer: RegimeConditionalSizer = self._make_sizer(da_estimate=0.60, break_even_da=0.55)
+        snapshot: PortfolioSnapshot = make_snapshot(equity=_DEFAULT_EQUITY)
+        signal: Signal = _make_signal(strength=1.0)
+        notional: float = sizer.size(signal, snapshot, 0.0)
+        assert notional > 0.0
+
+    def test_at_breakeven_da_returns_zero(self) -> None:
+        """DA exactly at break-even returns zero (no edge)."""
+        sizer: RegimeConditionalSizer = self._make_sizer(da_estimate=0.55, break_even_da=0.55)
+        snapshot: PortfolioSnapshot = make_snapshot(equity=_DEFAULT_EQUITY)
+        signal: Signal = _make_signal(strength=1.0)
+        notional: float = sizer.size(signal, snapshot, 0.0)
+        assert notional == pytest.approx(0.0)
+
+    def test_below_breakeven_da_returns_zero(self) -> None:
+        """DA below break-even returns zero (no-trade signal)."""
+        sizer: RegimeConditionalSizer = self._make_sizer(da_estimate=0.50, break_even_da=0.55)
+        snapshot: PortfolioSnapshot = make_snapshot(equity=_DEFAULT_EQUITY)
+        signal: Signal = _make_signal(strength=1.0)
+        notional: float = sizer.size(signal, snapshot, 0.0)
+        assert notional == pytest.approx(0.0)
+
+    def test_zero_equity_returns_zero(self) -> None:
+        """Zero equity yields zero notional even with good DA."""
+        sizer: RegimeConditionalSizer = self._make_sizer(da_estimate=0.70, break_even_da=0.55)
+        snapshot: PortfolioSnapshot = make_snapshot(equity=0.0, cash=0.0)
+        signal: Signal = _make_signal(strength=1.0)
+        notional: float = sizer.size(signal, snapshot, 0.0)
+        assert notional == pytest.approx(0.0)
+
+    def test_high_entropy_applies_reduction(self) -> None:
+        """PE above threshold halves notional (reduction=0.5)."""
+        sizer_normal: RegimeConditionalSizer = self._make_sizer(
+            da_estimate=0.60,
+            pe_estimate=0.95,
+            high_entropy_threshold=0.98,
+            high_entropy_reduction=0.5,
+        )
+        sizer_high_pe: RegimeConditionalSizer = self._make_sizer(
+            da_estimate=0.60,
+            pe_estimate=0.99,
+            high_entropy_threshold=0.98,
+            high_entropy_reduction=0.5,
+        )
+        snapshot: PortfolioSnapshot = make_snapshot(equity=_DEFAULT_EQUITY)
+        signal: Signal = _make_signal(strength=1.0)
+        normal_notional: float = sizer_normal.size(signal, snapshot, 0.0)
+        high_pe_notional: float = sizer_high_pe.size(signal, snapshot, 0.0)
+        assert high_pe_notional == pytest.approx(normal_notional * 0.5)
+
+    def test_low_entropy_no_reduction(self) -> None:
+        """PE at or below threshold does not apply entropy reduction."""
+        sizer: RegimeConditionalSizer = self._make_sizer(
+            da_estimate=0.60,
+            pe_estimate=0.97,
+            high_entropy_threshold=0.98,
+            high_entropy_reduction=0.5,
+        )
+        snapshot: PortfolioSnapshot = make_snapshot(equity=_DEFAULT_EQUITY)
+        signal: Signal = _make_signal(strength=1.0)
+        notional: float = sizer.size(signal, snapshot, 0.0)
+        # Should equal base * strength * da_scale without reduction
+        da_scale: float = (0.60 - 0.55) / 0.55
+        expected: float = _DEFAULT_EQUITY * 0.02 * 1.0 * da_scale
+        assert notional == pytest.approx(expected, rel=1e-6)
+
+    def test_tier_b_applies_kelly_multiplier(self) -> None:
+        """Tier-B flag reduces notional by tier_b_kelly_multiplier."""
+        sizer_a: RegimeConditionalSizer = self._make_sizer(
+            da_estimate=0.60, is_tier_b=False, tier_b_kelly_multiplier=0.5
+        )
+        sizer_b: RegimeConditionalSizer = self._make_sizer(
+            da_estimate=0.60, is_tier_b=True, tier_b_kelly_multiplier=0.5
+        )
+        snapshot: PortfolioSnapshot = make_snapshot(equity=_DEFAULT_EQUITY)
+        signal: Signal = _make_signal(strength=1.0)
+        tier_a_notional: float = sizer_a.size(signal, snapshot, 0.0)
+        tier_b_notional: float = sizer_b.size(signal, snapshot, 0.0)
+        assert tier_b_notional == pytest.approx(tier_a_notional * 0.5)
+
+    def test_both_reductions_stack_multiplicatively(self) -> None:
+        """High entropy AND tier-B reductions multiply together."""
+        sizer: RegimeConditionalSizer = self._make_sizer(
+            da_estimate=0.60,
+            pe_estimate=0.99,
+            high_entropy_threshold=0.98,
+            high_entropy_reduction=0.5,
+            is_tier_b=True,
+            tier_b_kelly_multiplier=0.5,
+        )
+        sizer_base: RegimeConditionalSizer = self._make_sizer(
+            da_estimate=0.60,
+            pe_estimate=0.90,
+            high_entropy_threshold=0.98,
+            high_entropy_reduction=0.5,
+            is_tier_b=False,
+            tier_b_kelly_multiplier=0.5,
+        )
+        snapshot: PortfolioSnapshot = make_snapshot(equity=_DEFAULT_EQUITY)
+        signal: Signal = _make_signal(strength=1.0)
+        base_notional: float = sizer_base.size(signal, snapshot, 0.0)
+        reduced_notional: float = sizer.size(signal, snapshot, 0.0)
+        assert reduced_notional == pytest.approx(base_notional * 0.5 * 0.5)
+
+    def test_strength_scales_notional(self) -> None:
+        """Lower signal strength proportionally reduces notional."""
+        sizer: RegimeConditionalSizer = self._make_sizer(da_estimate=0.60)
+        snapshot: PortfolioSnapshot = make_snapshot(equity=_DEFAULT_EQUITY)
+        full: Signal = _make_signal(strength=1.0)
+        half: Signal = _make_signal(strength=0.5)
+        full_notional: float = sizer.size(full, snapshot, 0.0)
+        half_notional: float = sizer.size(half, snapshot, 0.0)
+        assert half_notional == pytest.approx(full_notional * 0.5)
+
+    def test_higher_da_increases_notional(self) -> None:
+        """Higher DA estimate produces larger notional (greater edge)."""
+        sizer_low_da: RegimeConditionalSizer = self._make_sizer(da_estimate=0.57)
+        sizer_high_da: RegimeConditionalSizer = self._make_sizer(da_estimate=0.65)
+        snapshot: PortfolioSnapshot = make_snapshot(equity=_DEFAULT_EQUITY)
+        signal: Signal = _make_signal(strength=1.0)
+        low_notional: float = sizer_low_da.size(signal, snapshot, 0.0)
+        high_notional: float = sizer_high_da.size(signal, snapshot, 0.0)
+        assert high_notional > low_notional
+
+    def test_da_exactly_above_breakeven_produces_positive(self) -> None:
+        """Infinitesimally above break-even DA yields positive notional."""
+        sizer: RegimeConditionalSizer = self._make_sizer(da_estimate=0.550_001, break_even_da=0.55)
+        snapshot: PortfolioSnapshot = make_snapshot(equity=_DEFAULT_EQUITY)
+        signal: Signal = _make_signal(strength=1.0)
+        notional: float = sizer.size(signal, snapshot, 0.0)
+        assert notional > 0.0

--- a/src/tests/backtest/test_walk_forward.py
+++ b/src/tests/backtest/test_walk_forward.py
@@ -1,0 +1,357 @@
+"""Integration tests for WalkForwardRunner — expanding and rolling modes."""
+
+from __future__ import annotations
+
+from datetime import datetime, UTC
+
+import polars as pl
+import pytest
+
+from src.app.backtest.application.walk_forward import (
+    WalkForwardConfig,
+    WalkForwardResult,
+    WalkForwardRunner,
+    WindowMode,
+    WindowResult,
+    _generate_window_specs,
+)
+from src.app.backtest.domain.protocols import IStrategy
+from src.app.backtest.domain.value_objects import ExecutionConfig
+from src.app.ohlcv.domain.value_objects import Asset
+from src.tests.backtest.conftest import (
+    INITIAL_CASH,
+    AlwaysLongStrategy,
+    FixedNotionalSizer,
+    NeverTradeStrategy,
+    make_bars,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_T0: datetime = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+_BTC: Asset = Asset(symbol="BTCUSDT")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _AlwaysLongFactory:
+    """Strategy factory that always returns AlwaysLongStrategy."""
+
+    def __init__(self, asset: Asset) -> None:
+        self._asset: Asset = asset
+
+    def __call__(self, train_bars: pl.DataFrame) -> IStrategy:  # noqa: ARG002
+        return AlwaysLongStrategy(self._asset)
+
+
+class _NeverTradeFactory:
+    """Strategy factory that always returns NeverTradeStrategy."""
+
+    def __call__(self, train_bars: pl.DataFrame) -> IStrategy:  # noqa: ARG002
+        return NeverTradeStrategy()
+
+
+def _make_runner(
+    mode: WindowMode = WindowMode.EXPANDING,
+    train_bars: int = 5,
+    test_bars: int = 5,
+    step_bars: int | None = None,
+    commission_bps: float = 0.0,
+    factory: object | None = None,
+) -> WalkForwardRunner:
+    """Build a WalkForwardRunner with configurable parameters."""
+    wf_config: WalkForwardConfig = WalkForwardConfig(
+        mode=mode,
+        train_bars=train_bars,
+        test_bars=test_bars,
+        step_bars=step_bars,
+    )
+    exec_config: ExecutionConfig = ExecutionConfig(commission_bps=commission_bps)
+    used_factory: object = factory or _NeverTradeFactory()
+    sizer: FixedNotionalSizer = FixedNotionalSizer(notional=5_000.0)
+    return WalkForwardRunner(
+        config=wf_config,
+        execution_config=exec_config,
+        strategy_factory=used_factory,  # type: ignore[arg-type]
+        sizer=sizer,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestWalkForwardConfig
+# ---------------------------------------------------------------------------
+
+
+class TestWalkForwardConfig:
+    """Tests for WalkForwardConfig validation and defaults."""
+
+    def test_effective_step_bars_defaults_to_test_bars(self) -> None:
+        """step_bars defaults to test_bars when unset."""
+        config: WalkForwardConfig = WalkForwardConfig(train_bars=10, test_bars=5)
+        assert config.effective_step_bars == 5
+
+    def test_explicit_step_bars_respected(self) -> None:
+        """Explicit step_bars overrides default."""
+        config: WalkForwardConfig = WalkForwardConfig(train_bars=10, test_bars=5, step_bars=2)
+        assert config.effective_step_bars == 2
+
+    def test_zero_train_bars_raises(self) -> None:
+        """train_bars == 0 raises ValidationError."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            WalkForwardConfig(train_bars=0, test_bars=5)
+
+    def test_zero_test_bars_raises(self) -> None:
+        """test_bars == 0 raises ValidationError."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            WalkForwardConfig(train_bars=10, test_bars=0)
+
+
+# ---------------------------------------------------------------------------
+# TestGenerateWindowSpecs
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateWindowSpecs:
+    """Tests for _generate_window_specs helper."""
+
+    def test_expanding_single_window(self) -> None:
+        """Exactly train+test bars produces exactly one expanding window."""
+        from src.app.backtest.application.walk_forward import _WindowSpec
+
+        config: WalkForwardConfig = WalkForwardConfig(mode=WindowMode.EXPANDING, train_bars=5, test_bars=5)
+        specs: list[_WindowSpec] = _generate_window_specs(total_bars=10, config=config)
+        assert len(specs) == 1
+        assert specs[0].train_start_idx == 0
+        assert specs[0].train_end_idx == 5
+        assert specs[0].test_start_idx == 5
+        assert specs[0].test_end_idx == 10
+
+    def test_expanding_multiple_windows(self) -> None:
+        """Sufficient bars produce multiple expanding windows."""
+        from src.app.backtest.application.walk_forward import _WindowSpec
+
+        config: WalkForwardConfig = WalkForwardConfig(mode=WindowMode.EXPANDING, train_bars=5, test_bars=5)
+        specs: list[_WindowSpec] = _generate_window_specs(total_bars=20, config=config)
+        assert len(specs) == 3  # windows start at 5, 10, 15
+
+    def test_expanding_train_always_starts_at_zero(self) -> None:
+        """In expanding mode, train_start_idx is always 0 for all windows."""
+        from src.app.backtest.application.walk_forward import _WindowSpec
+
+        config: WalkForwardConfig = WalkForwardConfig(mode=WindowMode.EXPANDING, train_bars=3, test_bars=3)
+        specs: list[_WindowSpec] = _generate_window_specs(total_bars=15, config=config)
+        for spec in specs:
+            assert spec.train_start_idx == 0
+
+    def test_rolling_train_slides_forward(self) -> None:
+        """In rolling mode, train_start_idx advances with each window."""
+        from src.app.backtest.application.walk_forward import _WindowSpec
+
+        config: WalkForwardConfig = WalkForwardConfig(mode=WindowMode.ROLLING, train_bars=5, test_bars=5)
+        specs: list[_WindowSpec] = _generate_window_specs(total_bars=20, config=config)
+        assert len(specs) >= 2
+        # Second window's train_start > first window's train_start
+        assert specs[1].train_start_idx > specs[0].train_start_idx
+
+    def test_insufficient_bars_returns_empty(self) -> None:
+        """Fewer bars than train+test produces an empty list."""
+        from src.app.backtest.application.walk_forward import _WindowSpec
+
+        config: WalkForwardConfig = WalkForwardConfig(mode=WindowMode.EXPANDING, train_bars=10, test_bars=10)
+        specs: list[_WindowSpec] = _generate_window_specs(total_bars=15, config=config)
+        assert len(specs) == 0
+
+    def test_window_indices_are_sequential(self) -> None:
+        """Window indices start at 0 and increment by 1."""
+        from src.app.backtest.application.walk_forward import _WindowSpec
+
+        config: WalkForwardConfig = WalkForwardConfig(mode=WindowMode.EXPANDING, train_bars=5, test_bars=5)
+        specs: list[_WindowSpec] = _generate_window_specs(total_bars=30, config=config)
+        for i, spec in enumerate(specs):
+            assert spec.window_index == i
+
+
+# ---------------------------------------------------------------------------
+# TestWalkForwardRunnerErrors
+# ---------------------------------------------------------------------------
+
+
+class TestWalkForwardRunnerErrors:
+    """Tests for error conditions in WalkForwardRunner.run."""
+
+    def test_insufficient_bars_raises_value_error(self) -> None:
+        """Fewer bars than train+test raises ValueError."""
+        runner: WalkForwardRunner = _make_runner(train_bars=10, test_bars=10)
+        bars: pl.DataFrame = make_bars(15, start_price=40_000.0)
+        with pytest.raises(ValueError, match="Insufficient bars"):
+            runner.run(bars=bars, asset=_BTC)
+
+    def test_exactly_minimum_bars_runs_successfully(self) -> None:
+        """Exactly train+test bars runs without error (one window)."""
+        runner: WalkForwardRunner = _make_runner(train_bars=5, test_bars=5)
+        bars: pl.DataFrame = make_bars(10, start_price=40_000.0)
+        result: WalkForwardResult = runner.run(bars=bars, asset=_BTC)
+        assert len(result.windows) == 1
+
+
+# ---------------------------------------------------------------------------
+# TestWalkForwardRunnerExpanding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestWalkForwardRunnerExpanding:
+    """Integration tests for expanding-window walk-forward."""
+
+    def test_expanding_windows_count(self) -> None:
+        """Correct number of expanding windows generated for given bar count."""
+        runner: WalkForwardRunner = _make_runner(mode=WindowMode.EXPANDING, train_bars=5, test_bars=5)
+        bars: pl.DataFrame = make_bars(20, start_price=40_000.0)
+        result: WalkForwardResult = runner.run(bars=bars, asset=_BTC)
+        # Windows: test starts at 5, 10, 15 → 3 windows
+        assert len(result.windows) == 3
+
+    def test_expanding_windows_chronological_order(self) -> None:
+        """Windows are returned in chronological order."""
+        runner: WalkForwardRunner = _make_runner(mode=WindowMode.EXPANDING, train_bars=5, test_bars=5)
+        bars: pl.DataFrame = make_bars(20, start_price=40_000.0)
+        result: WalkForwardResult = runner.run(bars=bars, asset=_BTC)
+        for i in range(1, len(result.windows)):
+            assert result.windows[i].test_start > result.windows[i - 1].test_start
+
+    def test_expanding_train_end_advances_per_window(self) -> None:
+        """Expanding mode: each window has a larger training set than the previous."""
+        runner: WalkForwardRunner = _make_runner(mode=WindowMode.EXPANDING, train_bars=5, test_bars=5)
+        bars: pl.DataFrame = make_bars(20, start_price=40_000.0)
+        result: WalkForwardResult = runner.run(bars=bars, asset=_BTC)
+        for i in range(1, len(result.windows)):
+            prev: WindowResult = result.windows[i - 1]
+            curr: WindowResult = result.windows[i]
+            assert curr.train_end >= prev.train_end
+
+    def test_no_lookahead_train_end_before_test_start(self) -> None:
+        """Training window ends strictly before the test window starts."""
+        runner: WalkForwardRunner = _make_runner(mode=WindowMode.EXPANDING, train_bars=5, test_bars=5)
+        bars: pl.DataFrame = make_bars(20, start_price=40_000.0)
+        result: WalkForwardResult = runner.run(bars=bars, asset=_BTC)
+        for window in result.windows:
+            assert window.train_end < window.test_start
+
+    def test_equity_is_chained_across_windows(self) -> None:
+        """Final equity of window N equals initial equity of window N+1."""
+        runner: WalkForwardRunner = _make_runner(
+            mode=WindowMode.EXPANDING,
+            train_bars=5,
+            test_bars=5,
+            commission_bps=0.0,
+        )
+        bars: pl.DataFrame = make_bars(20, start_price=40_000.0)
+        result: WalkForwardResult = runner.run(bars=bars, asset=_BTC, initial_cash=INITIAL_CASH)
+
+        for i in range(1, len(result.windows)):
+            prev_final: float = result.windows[i - 1].backtest_result.equity_curve.values[-1]
+            curr_initial: float = result.windows[i].backtest_result.equity_curve.values[0]
+            # The initial cash of the next window matches the final equity of the previous
+            assert curr_initial == pytest.approx(prev_final, rel=1e-9)
+
+    def test_aggregate_equity_spans_all_windows(self) -> None:
+        """Aggregate equity curve timestamps span from first to last window."""
+        runner: WalkForwardRunner = _make_runner(mode=WindowMode.EXPANDING, train_bars=5, test_bars=5)
+        bars: pl.DataFrame = make_bars(20, start_price=40_000.0)
+        result: WalkForwardResult = runner.run(bars=bars, asset=_BTC)
+        # The aggregate equity curve should contain timestamps from all test windows
+        agg_ec_len: int = len(result.windows)
+        assert agg_ec_len > 0
+
+
+# ---------------------------------------------------------------------------
+# TestWalkForwardRunnerRolling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestWalkForwardRunnerRolling:
+    """Integration tests for rolling-window walk-forward."""
+
+    def test_rolling_train_window_fixed_size(self) -> None:
+        """Rolling mode: each train window has exactly train_bars bars."""
+        from src.app.backtest.application.walk_forward import _WindowSpec
+
+        train_bars_count: int = 5
+        config: WalkForwardConfig = WalkForwardConfig(
+            mode=WindowMode.ROLLING,
+            train_bars=train_bars_count,
+            test_bars=5,
+        )
+        specs: list[_WindowSpec] = _generate_window_specs(total_bars=25, config=config)
+        assert len(specs) > 0
+        for spec in specs:
+            actual_train_size: int = spec.train_end_idx - spec.train_start_idx
+            assert actual_train_size == train_bars_count
+
+    def test_rolling_more_windows_than_expanding(self) -> None:
+        """Rolling mode produces the same number of windows as expanding for same step."""
+        total: int = 30
+        bars: pl.DataFrame = make_bars(total, start_price=40_000.0)
+        runner_exp: WalkForwardRunner = _make_runner(mode=WindowMode.EXPANDING, train_bars=5, test_bars=5)
+        runner_roll: WalkForwardRunner = _make_runner(mode=WindowMode.ROLLING, train_bars=5, test_bars=5)
+        result_exp: WalkForwardResult = runner_exp.run(bars=bars, asset=_BTC)
+        result_roll: WalkForwardResult = runner_roll.run(bars=bars, asset=_BTC)
+        # Same step size → same window count
+        assert len(result_exp.windows) == len(result_roll.windows)
+
+    def test_rolling_no_lookahead(self) -> None:
+        """Rolling mode: train_end strictly before test_start for all windows."""
+        runner: WalkForwardRunner = _make_runner(mode=WindowMode.ROLLING, train_bars=5, test_bars=5)
+        bars: pl.DataFrame = make_bars(25, start_price=40_000.0)
+        result: WalkForwardResult = runner.run(bars=bars, asset=_BTC)
+        for window in result.windows:
+            assert window.train_end < window.test_start
+
+
+# ---------------------------------------------------------------------------
+# TestWalkForwardAggregateMetrics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestWalkForwardAggregateMetrics:
+    """Tests for aggregate metrics produced by walk-forward evaluation."""
+
+    def test_aggregate_n_trades_equals_sum_of_window_trades(self) -> None:
+        """Aggregate n_trades equals the sum of trades across all windows."""
+        runner: WalkForwardRunner = _make_runner(
+            mode=WindowMode.EXPANDING,
+            train_bars=5,
+            test_bars=5,
+            factory=_AlwaysLongFactory(_BTC),
+        )
+        bars: pl.DataFrame = make_bars(20, start_price=40_000.0)
+        result: WalkForwardResult = runner.run(bars=bars, asset=_BTC)
+        total_window_trades: int = sum(len(w.backtest_result.trades) for w in result.windows)
+        assert result.aggregate_metrics.n_trades == total_window_trades
+
+    def test_aggregate_config_preserved(self) -> None:
+        """WalkForwardResult preserves the config used."""
+        config: WalkForwardConfig = WalkForwardConfig(mode=WindowMode.EXPANDING, train_bars=5, test_bars=5)
+        exec_config: ExecutionConfig = ExecutionConfig(commission_bps=0.0)
+        runner: WalkForwardRunner = WalkForwardRunner(
+            config=config,
+            execution_config=exec_config,
+            strategy_factory=_NeverTradeFactory(),  # type: ignore[arg-type]
+            sizer=FixedNotionalSizer(),
+        )
+        bars: pl.DataFrame = make_bars(10, start_price=40_000.0)
+        result: WalkForwardResult = runner.run(bars=bars, asset=_BTC)
+        assert result.config.mode == WindowMode.EXPANDING
+        assert result.config.train_bars == 5


### PR DESCRIPTION
## Summary
- **186 new tests** covering the full backtest module (Phase 8A–8E)
- Domain validation (Signal, Trade, EquityCurve invariants) — 52 tests
- Position sizers (FixedFractional + RegimeConditional) — 21 tests
- Execution engine (commission, fill-on-next-open, SL/TP, staleness, edge cases) — 36 tests
- Metrics (Sharpe, Lo 2002 correction, drawdown, trade stats, buy-and-hold) — 30 tests
- Baselines (BuyAndHold first-bar-only, RandomStrategy frequency/seed) — 17 tests
- Walk-forward (expanding/rolling, equity chaining, no-lookahead) — 23 tests
- Cost sweep (fee ordering, zero commission, structure) — 14 tests

## Test plan
- [x] `just lint` passes
- [x] `just test src/tests/backtest/` — 186 passed in 0.24s
- [x] `just test` — 1429 passed (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)