### PR TITLE
feat(strategy): implement 5 batch trading strategies (9B)

### DIFF
--- a/src/app/strategy/application/__init__.py
+++ b/src/app/strategy/application/__init__.py
@@ -1,0 +1,1 @@
+"""Strategy application layer — batch signal generation implementations."""

--- a/src/app/strategy/application/donchian_breakout.py
+++ b/src/app/strategy/application/donchian_breakout.py
@@ -1,0 +1,123 @@
+"""Donchian breakout strategy — long-only channel breakout with ATR-scaled strength."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import polars as pl
+from pydantic import BaseModel
+from pydantic import Field as PydanticField
+
+from src.app.features.domain.value_objects import FeatureSet
+
+
+_EPSILON: float = 1e-12
+"""Division safety constant to prevent zero-division in strength calculation."""
+
+
+class DonchianBreakoutConfig(BaseModel, frozen=True):
+    """Configuration for the Donchian breakout strategy.
+
+    Controls the channel lookback period, the pre-computed ATR column
+    used for strength normalisation, and an ATR multiplier reserved for
+    trailing-stop logic in the downstream adapter layer.
+
+    Attributes:
+        channel_period: Number of bars for the rolling high channel.
+        atr_column: Name of the pre-computed ATR column in the feature set.
+        atr_multiplier: ATR multiplier for trailing stop (reserved for the
+            adapter layer that bridges to the backtest engine).
+    """
+
+    channel_period: Annotated[
+        int,
+        PydanticField(
+            default=20,
+            ge=5,
+            description="Lookback period for Donchian channel",
+        ),
+    ]
+
+    atr_column: str = "atr_14"
+
+    atr_multiplier: Annotated[
+        float,
+        PydanticField(
+            default=2.0,
+            gt=0.0,
+            description="ATR multiplier for trailing stop (reserved for adapter layer)",
+        ),
+    ]
+
+
+class DonchianBreakout(BaseModel, frozen=True):
+    """Long-only Donchian channel breakout strategy.
+
+    Generates ``"long"`` when the close price exceeds the upper Donchian
+    channel (rolling max of the *previous* bars' highs), and ``"flat"``
+    otherwise.  Signal strength is proportional to the breakout distance
+    normalised by ATR.
+
+    The upper channel is computed with ``shift(1)`` before
+    ``rolling_max`` to prevent look-ahead bias — the channel for bar
+    *t* uses only bars up to *t-1*.
+
+    Attributes:
+        config: Strategy configuration parameters.
+    """
+
+    config: DonchianBreakoutConfig = PydanticField(default_factory=DonchianBreakoutConfig)
+
+    @property
+    def name(self) -> str:
+        """Return strategy identifier.
+
+        Returns:
+            Strategy name string.
+        """
+        return "donchian_breakout"
+
+    def generate_signals(self, feature_set: FeatureSet) -> pl.DataFrame:
+        """Produce long-only breakout signals from the Donchian channel.
+
+        Long when ``close > upper_channel``, flat otherwise.  Strength
+        equals the ATR-normalised breakout distance clipped to ``[0, 1]``.
+
+        Args:
+            feature_set: Structured output from the feature matrix builder.
+
+        Returns:
+            Polars DataFrame with ``timestamp``, ``side``, and ``strength``
+            columns.
+        """
+        df: pl.DataFrame = feature_set.df
+        period: int = self.config.channel_period
+        atr_col: str = self.config.atr_column
+
+        upper: pl.Expr = (
+            pl.col("high")
+            .shift(1)
+            .rolling_max(
+                window_size=period,
+                min_samples=period,
+            )
+        )
+        enriched: pl.DataFrame = df.with_columns(upper.alias("_dc_upper"))
+
+        signals: pl.DataFrame = enriched.select(
+            pl.col("timestamp"),
+            pl.when(pl.col("close") > pl.col("_dc_upper"))
+            .then(pl.lit("long"))
+            .otherwise(pl.lit("flat"))
+            .alias("side"),
+            pl.when(pl.col("close") > pl.col("_dc_upper"))
+            .then(
+                ((pl.col("close") - pl.col("_dc_upper")) / (pl.col(atr_col) + _EPSILON)).clip(
+                    0.0,
+                    1.0,
+                ),
+            )
+            .otherwise(pl.lit(0.0))
+            .alias("strength"),
+        )
+        return signals

--- a/src/app/strategy/application/mean_reversion.py
+++ b/src/app/strategy/application/mean_reversion.py
@@ -1,0 +1,145 @@
+"""Mean reversion strategy — Bollinger Band fade with Hurst exponent regime filter."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import polars as pl
+from pydantic import BaseModel
+from pydantic import Field as PydanticField
+
+from src.app.features.domain.value_objects import FeatureSet
+
+
+_EPSILON: float = 1e-12
+"""Division safety constant to prevent zero-division in bandwidth normalisation."""
+
+
+class MeanReversionConfig(BaseModel, frozen=True):
+    """Configuration for the mean reversion strategy.
+
+    Controls the Bollinger Band parameters (window, number of standard
+    deviations) and the Hurst exponent regime filter that gates all
+    signals.  A wider band (2.5 sigma) is the default because crypto
+    return distributions exhibit excess kurtosis.
+
+    Attributes:
+        bb_window: Rolling window for Bollinger Bands mid and std.
+        bb_num_std: Number of standard deviations for the upper and lower
+            bands.  Default 2.5 accounts for crypto fat tails.
+        hurst_column: Name of the pre-computed Hurst exponent column.
+        hurst_threshold: Signal only when ``Hurst < threshold`` (indicating
+            a mean-reverting regime).
+    """
+
+    bb_window: Annotated[
+        int,
+        PydanticField(
+            default=20,
+            ge=5,
+            description="Bollinger Bands rolling window",
+        ),
+    ]
+
+    bb_num_std: Annotated[
+        float,
+        PydanticField(
+            default=2.5,
+            gt=0.0,
+            description="Number of std deviations for bands (2.5 for crypto kurtosis)",
+        ),
+    ]
+
+    hurst_column: str = "hurst_100"
+
+    hurst_threshold: Annotated[
+        float,
+        PydanticField(
+            default=0.5,
+            gt=0.0,
+            le=1.0,
+            description="Signal only when Hurst < threshold (mean-reverting regime)",
+        ),
+    ]
+
+
+class MeanReversion(BaseModel, frozen=True):
+    """Bollinger Band mean-reversion strategy with Hurst regime gate.
+
+    Generates ``"long"`` when the close falls below the lower Bollinger
+    Band and the Hurst exponent indicates a mean-reverting regime
+    (``Hurst < threshold``), ``"short"`` when the close exceeds the
+    upper band under the same regime filter, and ``"flat"`` otherwise.
+    Signal strength is the distance from the breached band normalised
+    by bandwidth.
+
+    Attributes:
+        config: Strategy configuration parameters.
+    """
+
+    config: MeanReversionConfig = PydanticField(default_factory=MeanReversionConfig)
+
+    @property
+    def name(self) -> str:
+        """Return strategy identifier.
+
+        Returns:
+            Strategy name string.
+        """
+        return "mean_reversion"
+
+    def generate_signals(self, feature_set: FeatureSet) -> pl.DataFrame:
+        """Produce mean-reversion signals gated by Hurst regime filter.
+
+        Long when ``close < lower_band`` and ``Hurst < threshold``,
+        short when ``close > upper_band`` and ``Hurst < threshold``,
+        flat otherwise.  Strength is proportional to the band-normalised
+        distance.
+
+        Args:
+            feature_set: Structured output from the feature matrix builder.
+
+        Returns:
+            Polars DataFrame with ``timestamp``, ``side``, and ``strength``
+            columns.
+        """
+        df: pl.DataFrame = feature_set.df
+        cfg: MeanReversionConfig = self.config
+        close: str = "close"
+
+        mid: pl.Expr = pl.col(close).rolling_mean(
+            window_size=cfg.bb_window,
+            min_samples=cfg.bb_window,
+        )
+        std: pl.Expr = pl.col(close).rolling_std(
+            window_size=cfg.bb_window,
+            min_samples=cfg.bb_window,
+        )
+        upper: pl.Expr = mid + std * cfg.bb_num_std
+        lower: pl.Expr = mid - std * cfg.bb_num_std
+        width: pl.Expr = upper - lower + pl.lit(_EPSILON)
+        hurst_ok: pl.Expr = pl.col(cfg.hurst_column) < cfg.hurst_threshold
+
+        enriched: pl.DataFrame = df.with_columns(
+            upper.alias("_bb_upper"),
+            lower.alias("_bb_lower"),
+            width.alias("_bb_width"),
+            hurst_ok.alias("_hurst_ok"),
+        )
+
+        signals: pl.DataFrame = enriched.select(
+            pl.col("timestamp"),
+            pl.when(pl.col("_hurst_ok") & (pl.col(close) < pl.col("_bb_lower")))
+            .then(pl.lit("long"))
+            .when(pl.col("_hurst_ok") & (pl.col(close) > pl.col("_bb_upper")))
+            .then(pl.lit("short"))
+            .otherwise(pl.lit("flat"))
+            .alias("side"),
+            pl.when(pl.col("_hurst_ok") & (pl.col(close) < pl.col("_bb_lower")))
+            .then(((pl.col("_bb_lower") - pl.col(close)) / pl.col("_bb_width")).clip(0.0, 1.0))
+            .when(pl.col("_hurst_ok") & (pl.col(close) > pl.col("_bb_upper")))
+            .then(((pl.col(close) - pl.col("_bb_upper")) / pl.col("_bb_width")).clip(0.0, 1.0))
+            .otherwise(pl.lit(0.0))
+            .alias("strength"),
+        )
+        return signals

--- a/src/app/strategy/application/momentum_crossover.py
+++ b/src/app/strategy/application/momentum_crossover.py
@@ -1,0 +1,116 @@
+"""Momentum crossover strategy — EMA crossover signal with configurable threshold."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import polars as pl
+from pydantic import BaseModel
+from pydantic import Field as PydanticField
+
+from src.app.features.domain.value_objects import FeatureSet
+
+
+class MomentumCrossoverConfig(BaseModel, frozen=True):
+    """Configuration for the momentum crossover strategy.
+
+    Controls which feature column carries the EMA crossover signal,
+    the minimum absolute crossover magnitude to generate a directional
+    signal, and ATR-based stop-loss / take-profit multipliers reserved
+    for the downstream adapter layer (not used in signal generation).
+
+    Attributes:
+        xover_column: Name of the EMA crossover column in the feature set.
+        signal_threshold: Minimum ``|ema_xover|`` to trigger a directional
+            signal.  Values below this threshold produce ``"flat"``.
+        atr_multiplier_sl: ATR multiplier for stop-loss distance (reserved
+            for the adapter layer that bridges to the backtest engine).
+        atr_multiplier_tp: ATR multiplier for take-profit distance (reserved
+            for the adapter layer that bridges to the backtest engine).
+    """
+
+    xover_column: str = "ema_xover_8_21"
+
+    signal_threshold: Annotated[
+        float,
+        PydanticField(
+            default=0.0,
+            ge=0.0,
+            description="Minimum |ema_xover| to generate a directional signal",
+        ),
+    ]
+
+    atr_multiplier_sl: Annotated[
+        float,
+        PydanticField(
+            default=2.0,
+            gt=0.0,
+            description="ATR multiplier for stop-loss (reserved for adapter layer)",
+        ),
+    ]
+
+    atr_multiplier_tp: Annotated[
+        float,
+        PydanticField(
+            default=3.0,
+            gt=0.0,
+            description="ATR multiplier for take-profit (reserved for adapter layer)",
+        ),
+    ]
+
+
+class MomentumCrossover(BaseModel, frozen=True):
+    """EMA crossover strategy producing directional signals.
+
+    Generates ``"long"`` when the crossover column exceeds the positive
+    threshold, ``"short"`` when it falls below the negative threshold,
+    and ``"flat"`` otherwise.  Signal strength equals the clipped
+    absolute crossover value.
+
+    Attributes:
+        config: Strategy configuration parameters.
+    """
+
+    config: MomentumCrossoverConfig = PydanticField(default_factory=MomentumCrossoverConfig)
+
+    @property
+    def name(self) -> str:
+        """Return strategy identifier.
+
+        Returns:
+            Strategy name string.
+        """
+        return "momentum_crossover"
+
+    def generate_signals(self, feature_set: FeatureSet) -> pl.DataFrame:
+        """Produce directional signals from the EMA crossover feature.
+
+        Long when ``ema_xover > threshold``, short when
+        ``ema_xover < -threshold``, flat otherwise.  Strength is the
+        clipped absolute crossover value in ``[0, 1]``.
+
+        Args:
+            feature_set: Structured output from the feature matrix builder.
+
+        Returns:
+            Polars DataFrame with ``timestamp``, ``side``, and ``strength``
+            columns.
+        """
+        df: pl.DataFrame = feature_set.df
+        xover: str = self.config.xover_column
+        thr: float = self.config.signal_threshold
+
+        signals: pl.DataFrame = df.select(
+            pl.col("timestamp"),
+            pl.when(pl.col(xover) > thr)
+            .then(pl.lit("long"))
+            .when(pl.col(xover) < -thr)
+            .then(pl.lit("short"))
+            .otherwise(pl.lit("flat"))
+            .alias("side"),
+            pl.when(pl.col(xover).abs() > thr)
+            .then(pl.col(xover).abs().clip(0.0, 1.0))
+            .otherwise(pl.lit(0.0))
+            .alias("strength"),
+        )
+        return signals

--- a/src/app/strategy/application/no_trade.py
+++ b/src/app/strategy/application/no_trade.py
@@ -1,0 +1,129 @@
+"""No-trade strategy — always flat with avoidance-confidence strength signal."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import polars as pl
+from pydantic import BaseModel
+from pydantic import Field as PydanticField
+
+from src.app.features.domain.value_objects import FeatureSet
+
+
+class NoTradeConfig(BaseModel, frozen=True):
+    """Configuration for the no-trade strategy.
+
+    Controls the global permutation entropy gate and the per-bar
+    low-volatility filter.  When the market exhibits near-random
+    behaviour (high PE), all bars are flat with maximum conviction.
+    Otherwise, individual bars with realised vol below the threshold
+    are flagged as untradeable.
+
+    Attributes:
+        pe_threshold: Permutation entropy above this value triggers the
+            global "market is random" gate (all bars flat, strength 1.0).
+        pe_value: Pre-computed global permutation entropy from the
+            statistical profiling module.
+        rv_column: Name of the pre-computed realised volatility column.
+        low_vol_threshold: Realised vol below this value makes a bar
+            untradeable (strength 1.0 for that bar).
+    """
+
+    pe_threshold: Annotated[
+        float,
+        PydanticField(
+            default=0.98,
+            gt=0.0,
+            le=1.0,
+            description="PE above this -> all bars flat",
+        ),
+    ]
+
+    pe_value: Annotated[
+        float,
+        PydanticField(
+            default=1.0,
+            ge=0.0,
+            le=1.0,
+            description="Global permutation entropy from profiling (pre-computed)",
+        ),
+    ]
+
+    rv_column: str = "rv_24"
+
+    low_vol_threshold: Annotated[
+        float,
+        PydanticField(
+            default=0.0,
+            ge=0.0,
+            description="RV below this -> flat for that bar",
+        ),
+    ]
+
+
+class NoTrade(BaseModel, frozen=True):
+    """Always-flat strategy encoding the decision not to trade.
+
+    Produces ``"flat"`` for every bar.  The ``strength`` column encodes
+    avoidance confidence: ``1.0`` means "definitely do not trade this
+    bar", ``0.0`` means "no particular reason to avoid".
+
+    Two filters are applied hierarchically:
+
+    1. **Global PE gate** — if the pre-computed permutation entropy
+       exceeds ``pe_threshold``, the entire series is deemed random
+       and all bars receive ``strength = 1.0``.
+    2. **Per-bar low-vol filter** — bars whose realised vol falls below
+       ``low_vol_threshold`` receive ``strength = 1.0``.
+
+    Attributes:
+        config: Strategy configuration parameters.
+    """
+
+    config: NoTradeConfig = PydanticField(default_factory=NoTradeConfig)
+
+    @property
+    def name(self) -> str:
+        """Return strategy identifier.
+
+        Returns:
+            Strategy name string.
+        """
+        return "no_trade"
+
+    def generate_signals(self, feature_set: FeatureSet) -> pl.DataFrame:
+        """Produce always-flat signals with avoidance-confidence strength.
+
+        When the global PE gate is active, all bars get ``strength=1.0``.
+        Otherwise, low-vol bars get ``strength=1.0`` and the rest get
+        ``strength=0.0``.
+
+        Args:
+            feature_set: Structured output from the feature matrix builder.
+
+        Returns:
+            Polars DataFrame with ``timestamp``, ``side``, and ``strength``
+            columns.
+        """
+        df: pl.DataFrame = feature_set.df
+        cfg: NoTradeConfig = self.config
+
+        # Global PE check — if market is near-random, all bars flat with max strength
+        if cfg.pe_value > cfg.pe_threshold:
+            signals: pl.DataFrame = df.select(
+                pl.col("timestamp"),
+                pl.lit("flat").alias("side"),
+                pl.lit(1.0).alias("strength"),
+            )
+            return signals
+
+        # Per-bar: low-vol bars get strength=1.0, others get strength=0.0
+        return df.select(
+            pl.col("timestamp"),
+            pl.lit("flat").alias("side"),
+            pl.when(pl.col(cfg.rv_column) < cfg.low_vol_threshold)
+            .then(pl.lit(1.0))
+            .otherwise(pl.lit(0.0))
+            .alias("strength"),
+        )

--- a/src/app/strategy/application/volatility_targeting.py
+++ b/src/app/strategy/application/volatility_targeting.py
@@ -1,0 +1,90 @@
+"""Volatility targeting strategy — always-long with inverse-vol position sizing."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import polars as pl
+from pydantic import BaseModel
+from pydantic import Field as PydanticField
+
+from src.app.features.domain.value_objects import FeatureSet
+
+
+_EPSILON: float = 1e-12
+"""Division safety constant to prevent zero-division in inverse-vol calculation."""
+
+
+class VolatilityTargetingConfig(BaseModel, frozen=True):
+    """Configuration for the volatility targeting strategy.
+
+    Controls the annualised target volatility level and the pre-computed
+    realised volatility column.  The strength signal is inversely
+    proportional to current realised vol, encoding a "trade smaller when
+    vol is high" heuristic.
+
+    Attributes:
+        target_vol: Target volatility level (must be on the same scale
+            as the ``rv_column`` values — typically annualised or
+            per-bar, depending on the feature pipeline).
+        rv_column: Name of the pre-computed realised volatility column
+            in the feature set.
+    """
+
+    target_vol: Annotated[
+        float,
+        PydanticField(
+            default=0.15,
+            gt=0.0,
+            le=1.0,
+            description="Target volatility level (same scale as rv column)",
+        ),
+    ]
+
+    rv_column: str = "rv_24"
+
+
+class VolatilityTargeting(BaseModel, frozen=True):
+    """Always-long strategy with inverse-volatility signal strength.
+
+    Every bar is marked ``"long"``.  Signal strength equals
+    ``target_vol / realised_vol``, clipped to ``[0, 1]``.  When
+    realised vol is high relative to the target, strength drops,
+    signalling the downstream position sizer to reduce exposure.
+
+    Attributes:
+        config: Strategy configuration parameters.
+    """
+
+    config: VolatilityTargetingConfig = PydanticField(default_factory=VolatilityTargetingConfig)
+
+    @property
+    def name(self) -> str:
+        """Return strategy identifier.
+
+        Returns:
+            Strategy name string.
+        """
+        return "volatility_targeting"
+
+    def generate_signals(self, feature_set: FeatureSet) -> pl.DataFrame:
+        """Produce always-long signals with inverse-vol strength scaling.
+
+        Strength is ``target_vol / rv``, clipped to ``[0, 1]``.
+
+        Args:
+            feature_set: Structured output from the feature matrix builder.
+
+        Returns:
+            Polars DataFrame with ``timestamp``, ``side``, and ``strength``
+            columns.
+        """
+        df: pl.DataFrame = feature_set.df
+        cfg: VolatilityTargetingConfig = self.config
+
+        signals: pl.DataFrame = df.select(
+            pl.col("timestamp"),
+            pl.lit("long").alias("side"),
+            (pl.lit(cfg.target_vol) / (pl.col(cfg.rv_column) + pl.lit(_EPSILON))).clip(0.0, 1.0).alias("strength"),
+        )
+        return signals


### PR DESCRIPTION
## Summary
- Implements 5 strategies for Phase 9B, all conforming to the batch `IStrategy` protocol from 9A
- **MomentumCrossover** — EMA crossover trend-following (long/short/flat), uses pre-computed `ema_xover_8_21`
- **DonchianBreakout** — long-only channel breakout with `shift(1)` anti-lookahead, ATR-normalised strength
- **MeanReversion** — 2.5σ Bollinger Band fade gated by `hurst_100 < 0.5` regime filter
- **VolatilityTargeting** — always-long inverse-vol sizing leveraging `rv_24` (no directional prediction needed)
- **NoTrade** — always-flat baseline with hierarchical PE gate + per-bar low-vol filter

## Design
- Each strategy is a frozen `BaseModel` with co-located Pydantic config class
- Pre-computed feature columns used where available; Donchian channel and 2.5σ Bollinger bands computed inline
- PE passed as config param (global series metric, not per-bar) — matches `RegimeConditionalSizer.pe_estimate` pattern
- SL/TP config fields reserved for adapter layer (Phase 10+)

## Test plan
- [x] `just lint` passes (ruff format + ruff lint + ty)
- [x] All 1429 existing tests pass
- [x] Phase 9C will add unit tests on synthetic data for each strategy

Closes #88, closes #89, closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)